### PR TITLE
Allow replacing review images when editing

### DIFF
--- a/app/routes/products.$handle.tsx
+++ b/app/routes/products.$handle.tsx
@@ -731,7 +731,7 @@ export default function Product() {
 
   const handleEditReview = async (
     reviewToEdit: any,
-    updates: {text: string; title: string; stars: number},
+    updates: {text: string; title: string; stars: number; image?: File | null},
   ) => {
     if (!customerId || !reviewToEdit?.createdAt) return;
 
@@ -743,6 +743,9 @@ export default function Product() {
     form.append('stars', updates.stars.toString());
     form.append('title', updates.title);
     form.append('customerName', customerName);
+    if (updates.image) {
+      form.append('image', updates.image);
+    }
 
     try {
       const response = await fetch('/api/edit_review', {


### PR DESCRIPTION
## Summary
- show existing review fields and current image when editing
- allow uploading a new image while editing and send it with review updates
- replace stored review image on the server and remove the previous upload

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692c9f1e4098832f942e34b0f8efde77)