### PR TITLE
Add carousel display for product reviews

### DIFF
--- a/app/components/global/ProductReviewsCarousel.tsx
+++ b/app/components/global/ProductReviewsCarousel.tsx
@@ -1,0 +1,89 @@
+import {useEffect, useMemo, useState} from 'react';
+import ProductReviewsDisplay, {Review} from './ProductReviewsDisplay';
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
+} from '../ui/carousel';
+
+interface ProductReviewsCarouselProps {
+  reviews: Review[];
+  currentCustomerId?: string;
+  onRemove?: (review: Review) => Promise<void> | void;
+  onEdit?: (
+    review: Review,
+    updates: {text: string; title: string; stars: number; image?: File | null},
+  ) => Promise<void> | void;
+}
+
+export default function ProductReviewsCarousel({
+  reviews,
+  currentCustomerId,
+  onRemove,
+  onEdit,
+}: ProductReviewsCarouselProps) {
+  const [windowWidth, setWindowWidth] = useState<number | undefined>(undefined);
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowWidth(window.innerWidth);
+    }
+    window.addEventListener('resize', handleResize);
+    handleResize();
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
+  const sortedReviews = useMemo(() => {
+    return [...(reviews ?? [])].sort((first, second) => {
+      const secondTime = new Date(second?.createdAt ?? '').getTime() || 0;
+      const firstTime = new Date(first?.createdAt ?? '').getTime() || 0;
+      return secondTime - firstTime;
+    });
+  }, [reviews]);
+
+  const slidesPerView = useMemo(() => {
+    if (windowWidth === undefined) return 3;
+    if (windowWidth >= 1024) return 3;
+    if (windowWidth >= 720) return 2;
+    return 1;
+  }, [windowWidth]);
+
+  const slideStyle = useMemo(() => {
+    const percent = 100 / slidesPerView;
+    return {flex: `0 0 ${percent}%`, maxWidth: `${percent}%`};
+  }, [slidesPerView]);
+
+  if (!sortedReviews.length) return null;
+
+  return (
+    <Carousel
+      className="you-may-like-carousel w-full"
+      opts={{
+        loop: true,
+        align: slidesPerView === 1 ? 'center' : 'start',
+        slidesToScroll: 1,
+      }}
+    >
+      <CarouselContent className="!flex !items-stretch !justify-start">
+        {sortedReviews.map((review, index) => (
+          <CarouselItem
+            key={review?.createdAt ?? index}
+            className="flex justify-center items-stretch"
+            style={slideStyle}
+          >
+            <ProductReviewsDisplay
+              review={review}
+              currentCustomerId={currentCustomerId}
+              onRemove={onRemove}
+              onEdit={onEdit}
+            />
+          </CarouselItem>
+        ))}
+      </CarouselContent>
+      <CarouselPrevious />
+      <CarouselNext />
+    </Carousel>
+  );
+}

--- a/app/components/global/ProductReviewsDisplay.tsx
+++ b/app/components/global/ProductReviewsDisplay.tsx
@@ -4,7 +4,7 @@ import {Card, CardContent, CardHeader} from '../ui/card';
 import {Rating, RatingButton} from 'components/ui/shadcn-io/rating';
 import {Button} from '../ui/button';
 import {Input} from '../ui/input';
-interface Review {
+export interface Review {
   text?: string;
   createdAt?: string;
   customerId?: string;

--- a/app/routes/products.$handle.tsx
+++ b/app/routes/products.$handle.tsx
@@ -60,7 +60,7 @@ import {
 import ThreeUpCarouselBox from '~/components/global/ThreeUpCarouselBox';
 import ReviewForm from '~/components/form/ReviewForm';
 import {CUSTOMER_DETAILS_QUERY} from '~/graphql/customer-account/CustomerDetailsQuery';
-import ProductReviewsDisplay from '~/components/global/ProductReviewsDisplay';
+import ProductReviewsCarousel from '~/components/global/ProductReviewsCarousel';
 import {Rating, RatingButton} from 'components/ui/shadcn-io/rating';
 
 export const meta: MetaFunction<typeof loader> = ({data}) => {
@@ -1837,17 +1837,12 @@ export default function Product() {
             </div>
           </div>
           <div className="my-5" id="reviews">
-            <div>
-              {reviewsList?.map((review: any, index: number) => (
-                <ProductReviewsDisplay
-                  key={review?.createdAt ?? index}
-                  review={review}
-                  currentCustomerId={customerId}
-                  onRemove={handleRemoveReview}
-                  onEdit={handleEditReview}
-                />
-              ))}
-            </div>
+            <ProductReviewsCarousel
+              reviews={reviewsList}
+              currentCustomerId={customerId}
+              onRemove={handleRemoveReview}
+              onEdit={handleEditReview}
+            />
             <ReviewForm
               productId={product.id}
               customerId={customerId}


### PR DESCRIPTION
## Summary
- add a dedicated carousel component to present product reviews three-at-a-time with looping navigation
- sort reviews by most recent before rendering to ensure the newest feedback is shown first
- integrate the carousel into the product page review section

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ca44285fc832fab1087f2bea38c30)