### PR TITLE
Ensure review cards stay uniform width

### DIFF
--- a/app/components/global/ProductReviewsDisplay.tsx
+++ b/app/components/global/ProductReviewsDisplay.tsx
@@ -107,7 +107,7 @@ const ProductReviewsDisplay = ({
 
   return (
     <>
-      <Card className="mb-5">
+      <Card className="review-card mb-5 h-full w-full">
         {isEditing ? (
           <>
             <div className="review-container">
@@ -224,12 +224,12 @@ const ProductReviewsDisplay = ({
                 ) : null}
                 <Card className="mt-3 mb-1">
                   <CardHeader>
-                    <p>
+                    <p className="review-title">
                       <strong>{displayTitle}</strong>
                     </p>
                   </CardHeader>
                   <CardContent>
-                    <p>{displayText}</p>
+                    <p className="review-body">{displayText}</p>
                   </CardContent>
                 </Card>
               </div>

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -1218,6 +1218,17 @@ span {
   color: rgb(214, 183, 72);
 }
 
+.review-card {
+  width: 100%;
+  height: 100%;
+}
+
+.review-title,
+.review-body {
+  word-break: break-word;
+  overflow-wrap: break-word;
+}
+
 .review-container {
   display: grid;
   grid-template-columns: 4fr 1fr;


### PR DESCRIPTION
## Summary
- ensure review cards always fill their slide space
- prevent long review titles or bodies from affecting card width by enforcing word wrapping

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692e1cca03f4832f8aea1ab9bc4a734b)