### PR TITLE
Adjust header layout for tablet breakpoint

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -267,24 +267,24 @@ export function HeaderMenu({
       )}
       {windowWidth != undefined && windowWidth >= 810 && windowWidth < 1024 && (
         <>
-          <nav className={className} role="navigation">
-            <div className="nav-logo-container 1 inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 text-primary underline-offset-4 hover:underline h-9 px-4 py-2">
-              <NavLink
-                end
-                onClick={close}
-                prefetch="intent"
-                to="/"
-                className="logo-container"
-              >
-                <img
-                  src={imageURL}
-                  className="logo"
-                  style={{height: '2.5rem'}}
-                ></img>
-              </NavLink>
-            </div>
-            <div className="2 flex items-center nav-links-container">
-              <div className="2.1 flex justify-center w-full">
+          <nav className={`${className} flex flex-col gap-3`} role="navigation">
+            <div className="flex items-center gap-4">
+              <div className="nav-logo-container 1 inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 text-primary underline-offset-4 hover:underline h-9 px-4 py-2 shrink-0">
+                <NavLink
+                  end
+                  onClick={close}
+                  prefetch="intent"
+                  to="/"
+                  className="logo-container"
+                >
+                  <img
+                    src={imageURL}
+                    className="logo"
+                    style={{height: '2.5rem'}}
+                  ></img>
+                </NavLink>
+              </div>
+              <div className="flex-1 flex justify-center">
                 {menuFirstHalf.map((item) => {
                   console.log(menu, '2222');
 
@@ -343,73 +343,73 @@ export function HeaderMenu({
                   return <>{renderContent}</>;
                 })}
               </div>
-              <div className="2.2 flex justify-center w-full">
-                {menuSecondHalf.map((item) => {
-                  console.log(menu, '2222');
-
-                  if (!item.url) return null;
-
-                  // if the url is internal, we strip the domain
-                  const url =
-                    item.url.includes('myshopify.com') ||
-                    item.url.includes(publicStoreDomain) ||
-                    item.url.includes(primaryDomainUrl)
-                      ? new URL(item.url).pathname
-                      : item.url;
-
-                  let renderContent;
-                  switch (item.title) {
-                    case 'About':
-                      renderContent = (
-                        <AboutDropdown
-                          menuItems={item}
-                          publicStoreDomain={publicStoreDomain}
-                          primaryDomainUrl={primaryDomainUrl}
-                        ></AboutDropdown>
-                      );
-                      break;
-                    case 'Services':
-                      renderContent = (
-                        <ServicesDropdown
-                          menuItems={item}
-                          publicStoreDomain={publicStoreDomain}
-                          primaryDomainUrl={primaryDomainUrl}
-                        ></ServicesDropdown>
-                      );
-                      break;
-
-                    default:
-                      console.log(url, '888url');
-
-                      renderContent = (
-                        <NavLink
-                          className="relative z-10"
-                          end
-                          onClick={close}
-                          prefetch="intent"
-                          to={url}
-                        >
-                          <Button
-                            variant="ghost2"
-                            className="relative group px-3 py-2 rounded-md transition-colors hover:bg-accent hover:text-primary cursor-pointer"
-                          >
-                            {item.title}
-                            {/* animated underline */}
-                            <span className="absolute bottom-0 left-[2px] right-[2px] h-[2px] bg-primary scale-x-0 transition-transform duration-300 group-hover:scale-x-100 origin-center" />
-                          </Button>
-                        </NavLink>
-                      );
-                      break;
-                  }
-                  return <>{renderContent}</>;
-                })}
-              </div>
+              {cart && (
+                <div className="flex gap-4 items-center ctas-cart-search-container">
+                  <HeaderCtas cart={cart} isLoggedIn={isLoggedIn} />
+                </div>
+              )}
             </div>
-            {cart && (
-              <div className="3 flex gap-4 items-center ctas-cart-search-container">
-                <HeaderCtas cart={cart} isLoggedIn={isLoggedIn} />
-              </div>
-            )}
+            <div className="flex justify-center">
+              {menuSecondHalf.map((item) => {
+                console.log(menu, '2222');
+
+                if (!item.url) return null;
+
+                // if the url is internal, we strip the domain
+                const url =
+                  item.url.includes('myshopify.com') ||
+                  item.url.includes(publicStoreDomain) ||
+                  item.url.includes(primaryDomainUrl)
+                    ? new URL(item.url).pathname
+                    : item.url;
+
+                let renderContent;
+                switch (item.title) {
+                  case 'About':
+                    renderContent = (
+                      <AboutDropdown
+                        menuItems={item}
+                        publicStoreDomain={publicStoreDomain}
+                        primaryDomainUrl={primaryDomainUrl}
+                      ></AboutDropdown>
+                    );
+                    break;
+                  case 'Services':
+                    renderContent = (
+                      <ServicesDropdown
+                        menuItems={item}
+                        publicStoreDomain={publicStoreDomain}
+                        primaryDomainUrl={primaryDomainUrl}
+                      ></ServicesDropdown>
+                    );
+                    break;
+
+                  default:
+                    console.log(url, '888url');
+
+                    renderContent = (
+                      <NavLink
+                        className="relative z-10"
+                        end
+                        onClick={close}
+                        prefetch="intent"
+                        to={url}
+                      >
+                        <Button
+                          variant="ghost2"
+                          className="relative group px-3 py-2 rounded-md transition-colors hover:bg-accent hover:text-primary cursor-pointer"
+                        >
+                          {item.title}
+                          {/* animated underline */}
+                          <span className="absolute bottom-0 left-[2px] right-[2px] h-[2px] bg-primary scale-x-0 transition-transform duration-300 group-hover:scale-x-100 origin-center" />
+                        </Button>
+                      </NavLink>
+                    );
+                    break;
+                }
+                return <>{renderContent}</>;
+              })}
+            </div>
           </nav>
         </>
       )}


### PR DESCRIPTION
## Summary
- restructure the 810–1024px header layout into two rows with centered menu halves
- keep the logo at a fixed size while positioning CTAs on the top row and second-half menu on the bottom row

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693906e5c3b4832fbb4a6caa01e34167)