### PR TITLE
Add optional image uploads to contact form

### DIFF
--- a/app/routes/api.contact.tsx
+++ b/app/routes/api.contact.tsx
@@ -1,7 +1,35 @@
 import {json, type ActionFunctionArgs} from '@shopify/remix-oxygen';
+import {uploadImage} from '~/lib/supabase.server';
 
-export async function action({request}: ActionFunctionArgs) {
-  const body = await request.json();
+export async function action({request, context}: ActionFunctionArgs) {
+  const formData = await request.formData();
+  const name = (formData.get('name') as string) ?? '';
+  const email = (formData.get('email') as string) ?? '';
+  const message = (formData.get('message') as string) ?? '';
+  const contactImages = formData.getAll('contactImages');
+  const imageFiles = contactImages.filter(
+    (file): file is File => file instanceof File && file.size > 0,
+  );
+
+  if (imageFiles.length > 3) {
+    return json({error: 'You can upload up to 3 images.'}, {status: 400});
+  }
+
+  const uploadedImages: string[] = [];
+
+  try {
+    for (const image of imageFiles) {
+      const url = await uploadImage(context.env, image);
+      uploadedImages.push(url);
+    }
+  } catch (error) {
+    console.error('Image upload failed:', error);
+    return json(
+      {error: 'Failed to upload images. Please try again.'},
+      {status: 500},
+    );
+  }
+
   const courierToken = 'dk_prod_YD7MPFEFARMTTYM3ASDX55T6ZD08';
   try {
     const response = await fetch('https://api.courier.com/send', {
@@ -17,8 +45,10 @@ export async function action({request}: ActionFunctionArgs) {
           },
           template: 'Q6HCEKAAFXM5CFH41HR0RSHRWH6R',
           data: {
-            //@ts-expect-error body is an object
-            ...body,
+            name,
+            email,
+            message,
+            contactImages: uploadedImages,
           },
           routing: {
             method: 'single',


### PR DESCRIPTION
## Summary
- add a multi-image upload option to the contact form with a three-file limit and clear status messaging
- send contact submissions as multipart form data and upload selected images to Supabase storage
- include uploaded contact image URLs in the Courier payload for recipient visibility

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942fbb2d800832fb2b125f868f7a95c)