### PR TITLE
Add optional image uploads to contact form

### DIFF
--- a/app/components/form/Contact.tsx
+++ b/app/components/form/Contact.tsx
@@ -1,4 +1,4 @@
-import {useState} from 'react';
+import {useRef, useState} from 'react';
 import {Label} from '~/components/ui/label';
 import {Input} from '~/components/ui/input';
 import {Button} from '~/components/ui/button';
@@ -11,6 +11,9 @@ export default function ContactForm() {
     message: '',
   });
 
+  const [selectedImages, setSelectedImages] = useState<File[]>([]);
+  const [imageError, setImageError] = useState('');
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [status, setStatus] = useState('');
 
   const handleChange = (
@@ -23,16 +26,50 @@ export default function ContactForm() {
     }));
   };
 
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? []);
+    setImageError('');
+
+    if (files.length > 3) {
+      setImageError('You can upload up to 3 images.');
+      e.target.value = '';
+      return;
+    }
+
+    setSelectedImages(files);
+  };
+
+  const triggerFileSelect = () => fileInputRef.current?.click();
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (imageError) {
+      setStatus(imageError);
+      return;
+    }
     setStatus('Sending...');
 
     try {
+      const formPayload = new FormData();
+      formPayload.append('name', formData.name);
+      formPayload.append('email', formData.email);
+      formPayload.append('message', formData.message);
+
+      selectedImages.forEach((image) => {
+        formPayload.append('contactImages', image);
+      });
+
       const response = await fetch('/api/contact', {
         method: 'POST',
-        headers: {'Content-Type': 'application/json'},
-        body: JSON.stringify(formData),
+        body: formPayload,
       });
+
+      let result: any = null;
+      try {
+        result = await response.json();
+      } catch (error) {
+        console.error('Failed to parse response JSON:', error);
+      }
 
       if (response.ok) {
         setStatus('Message sent successfully!');
@@ -41,8 +78,15 @@ export default function ContactForm() {
           email: '',
           message: '',
         });
+        setSelectedImages([]);
+        setImageError('');
+        if (fileInputRef.current) {
+          fileInputRef.current.value = '';
+        }
       } else {
-        setStatus('Failed to submit form. Please try again.');
+        const errorMessage =
+          result?.error || 'Failed to submit form. Please try again.';
+        setStatus(errorMessage);
       }
     } catch (error) {
       console.error('Error:', error);
@@ -101,15 +145,46 @@ export default function ContactForm() {
               onChange={handleChange}
               placeholder="Type your message"
               rows={4}
-              className="w-full message bg-background border border-input border-gray-300 dark:border-gray-700 rounded-sm p-2"
-              required
-            />
-          </div>
-          <div className="submit ">
-            <Button type="submit" className="w-50 bg-primary">
-              Submit
+            className="w-full message bg-background border border-input border-gray-300 dark:border-gray-700 rounded-sm p-2"
+            required
+          />
+        </div>
+        <div className="space-y-2">
+          <Label htmlFor="contactImages">Upload Images (optional)</Label>
+          <input
+            id="contactImages"
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            multiple
+            className="hidden"
+            onChange={handleFileChange}
+          />
+          <div className="flex items-center gap-3">
+            <Button
+              type="button"
+              variant="outline"
+              onClick={triggerFileSelect}
+              className="cursor-pointer"
+            >
+              Upload Images
             </Button>
+            {selectedImages.length > 0 && (
+              <div className="text-sm text-muted-foreground">
+                Selected ({selectedImages.length}/3):{' '}
+                {selectedImages.map((file) => file.name).join(', ')}
+              </div>
+            )}
           </div>
+          {imageError && (
+            <p className="text-sm text-red-500 font-medium">{imageError}</p>
+          )}
+        </div>
+        <div className="submit ">
+          <Button type="submit" className="w-50 bg-primary">
+            Submit
+          </Button>
+        </div>
         </div>
         {status && <p className="text-center text-gray-600">{status}</p>}
       </form>

--- a/app/routes/api.contact.tsx
+++ b/app/routes/api.contact.tsx
@@ -1,7 +1,35 @@
 import {json, type ActionFunctionArgs} from '@shopify/remix-oxygen';
+import {uploadImage} from '~/lib/supabase.server';
 
-export async function action({request}: ActionFunctionArgs) {
-  const body = await request.json();
+export async function action({request, context}: ActionFunctionArgs) {
+  const formData = await request.formData();
+  const name = (formData.get('name') as string) ?? '';
+  const email = (formData.get('email') as string) ?? '';
+  const message = (formData.get('message') as string) ?? '';
+  const contactImages = formData.getAll('contactImages');
+  const imageFiles = contactImages.filter(
+    (file): file is File => file instanceof File && file.size > 0,
+  );
+
+  if (imageFiles.length > 3) {
+    return json({error: 'You can upload up to 3 images.'}, {status: 400});
+  }
+
+  const uploadedImages: string[] = [];
+
+  try {
+    for (const image of imageFiles) {
+      const url = await uploadImage(context.env, image);
+      uploadedImages.push(url);
+    }
+  } catch (error) {
+    console.error('Image upload failed:', error);
+    return json(
+      {error: 'Failed to upload images. Please try again.'},
+      {status: 500},
+    );
+  }
+
   const courierToken = 'dk_prod_YD7MPFEFARMTTYM3ASDX55T6ZD08';
   try {
     const response = await fetch('https://api.courier.com/send', {
@@ -17,8 +45,10 @@ export async function action({request}: ActionFunctionArgs) {
           },
           template: 'Q6HCEKAAFXM5CFH41HR0RSHRWH6R',
           data: {
-            //@ts-expect-error body is an object
-            ...body,
+            name,
+            email,
+            message,
+            contactImages: uploadedImages,
           },
           routing: {
             method: 'single',
@@ -27,6 +57,16 @@ export async function action({request}: ActionFunctionArgs) {
         },
       }),
     });
+
+    if (!response.ok) {
+      const text = await response.text();
+      console.error('Courier request failed:', response.status, text);
+      return json(
+        {error: 'Failed to send message notification.'},
+        {status: 500},
+      );
+    }
+
     const JSONResponse = await response.json();
     console.log(JSONResponse, '0987');
     return json({success: true, result: JSONResponse});


### PR DESCRIPTION
## Summary
- add a multi-image upload option to the contact form with a three-file limit and clear status messaging
- send contact submissions as multipart form data and upload selected images to Supabase storage
- include uploaded contact image URLs in the Courier payload for recipient visibility
- harden contact submission handling with safer JSON parsing and courier error reporting

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942fbb2d800832fb2b125f868f7a95c)