### PR TITLE
Add toast notifications for wishlist actions

### DIFF
--- a/app/components/eproducts/EProductsContainer.tsx
+++ b/app/components/eproducts/EProductsContainer.tsx
@@ -20,6 +20,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from '../ui/tooltip';
+import {toast} from 'sonner';
 
 type shopifyImage = {url: string; altText: string};
 function EProductsContainer({
@@ -135,6 +136,7 @@ function EProductsContainer({
       });
       const json = await response.json();
       setWishlistItem(true);
+      toast.success('Added to Favorites');
       setPendingWishlistChange(false);
     } catch (error) {
       setWishlistItem(false);
@@ -155,6 +157,7 @@ function EProductsContainer({
       });
       const json = await response.json();
       setWishlistItem(false);
+      toast.success('Removed from Favorites');
       setPendingWishlistChange(false);
     } catch (error) {
       setWishlistItem(true);

--- a/app/components/products/productCarousel.tsx
+++ b/app/components/products/productCarousel.tsx
@@ -26,6 +26,7 @@ import {
   TooltipTrigger,
 } from '../ui/tooltip';
 import {useIsLoggedIn} from '~/lib/hooks';
+import {toast} from 'sonner';
 
 
 type shopifyImage = {url: string; altText: string};
@@ -303,6 +304,7 @@ export const ProductCarousel = ({
       });
       const json = await response.json();
       setWishlistItem(true);
+      toast.success('Added to Favorites');
       setPendingWishlistChange(false);
 
     } catch (error) {
@@ -324,6 +326,7 @@ export const ProductCarousel = ({
       });
       const json = await response.json();
       setWishlistItem(false);
+      toast.success('Removed from Favorites');
       setPendingWishlistChange(false);
 
     } catch (error) {

--- a/app/routes/products.$handle.tsx
+++ b/app/routes/products.$handle.tsx
@@ -37,6 +37,7 @@ import {
   AccordionItem,
   AccordionTrigger,
 } from '~/components/ui/accordion';
+import {toast} from 'sonner';
 import {
   Carousel,
   CarouselApi,
@@ -821,6 +822,7 @@ export default function Product() {
       });
       const json = await response.json();
       setWishlistItem(true);
+      toast.success('Added to Favorites');
       setPendingWishlistChange(false);
     } catch (error) {
       setWishlistItem(false);
@@ -841,6 +843,7 @@ export default function Product() {
       });
       const json = await response.json();
       setWishlistItem(false);
+      toast.success('Removed from Favorites');
       setPendingWishlistChange(false);
     } catch (error) {
       setWishlistItem(true);


### PR DESCRIPTION
## Summary
- show Shadcn/Sonner toast notifications when adding or removing favorites
- apply toast feedback across product page, product cards, and carousel items

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945b4ae5164832f9fc0e4a92b4080ff)