### PR TITLE
Add navigation to favorites page from toast actions

### DIFF
--- a/app/components/eproducts/EProductsContainer.tsx
+++ b/app/components/eproducts/EProductsContainer.tsx
@@ -5,7 +5,7 @@ import {ProductItemFragment} from 'storefrontapi.generated';
 import {useVariantUrl} from '~/lib/variants';
 import EProductPreview from './EProductPreview';
 import {Money} from '@shopify/hydrogen';
-import {Link} from '@remix-run/react';
+import {Link, useNavigate} from '@remix-run/react';
 import {useAside} from '../Aside';
 import {useIsLoggedIn, useIsVideoInCart} from '~/lib/hooks';
 import {CartReturn} from '@shopify/hydrogen';
@@ -119,6 +119,7 @@ function EProductsContainer({
     .filter(Boolean)
     .join(', ');
   
+  const navigate = useNavigate();
   const loginValue = useIsLoggedIn(isLoggedIn);
   const [wishlistItem, setWishlistItem] = useState(isInWishlist);
   const [pendingWishlistChange, setPendingWishlistChange] = useState(false);
@@ -139,10 +140,7 @@ function EProductsContainer({
       toast.success('Added to Favorites', {
         action: {
           label: 'View All Favorites',
-          onClick: () => {
-            console.log('Navigate to favorites');
-            // e.g. navigate("/favorites")
-          },
+          onClick: () => navigate('/account/favorites'),
         },
       });
       setPendingWishlistChange(false);
@@ -168,10 +166,7 @@ function EProductsContainer({
       toast.success('Removed from Favorites', {
         action: {
           label: 'View All Favorites',
-          onClick: () => {
-            
-            // navigate("/favorites")
-          },
+          onClick: () => navigate('/account/favorites'),
         },
       });
       setPendingWishlistChange(false);

--- a/app/components/products/productCarousel.tsx
+++ b/app/components/products/productCarousel.tsx
@@ -7,7 +7,7 @@ import {
   CarouselItem,
   CarouselApi,
 } from '../ui/carousel';
-import {Link, NavLink, Navigate, useLoaderData} from '@remix-run/react';
+import {Link, NavLink, Navigate, useLoaderData, useNavigate} from '@remix-run/react';
 import {Button} from '../ui/button';
 import {ChevronLeftIcon, ChevronRightIcon, Divide} from 'lucide-react';
 import {Money} from '@shopify/hydrogen';
@@ -111,6 +111,7 @@ export const ProductCarousel = ({
     item?.url?.includes('outer-carousel-'),
   );
 
+  const navigate = useNavigate();
   const [carouselApi, setCarouselApi] = useState<CarouselApi | null>(null);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [totalItems, setTotalItems] = useState(0);
@@ -295,10 +296,7 @@ export const ProductCarousel = ({
       toast.success('Added to Favorites', {
         action: {
           label: 'View All Favorites',
-          onClick: () => {
-            console.log('Navigate to favorites');
-            // e.g. navigate("/favorites")
-          },
+          onClick: () => navigate('/account/favorites'),
         },
       });
       setPendingWishlistChange(false);
@@ -323,9 +321,7 @@ export const ProductCarousel = ({
       toast.success('Removed from Favorites', {
         action: {
           label: 'View All Favorites',
-          onClick: () => {
-            // navigate("/favorites")
-          },
+          onClick: () => navigate('/account/favorites'),
         },
       });
       setPendingWishlistChange(false);


### PR DESCRIPTION
## Summary
- update favorites toast action in product cards and carousel to navigate to the favorites page
- wire toast actions to Remix navigation so users can open /account/favorites directly

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ca1403a10832f90a67c3733efd245)