### PR TITLE
Add mobile dropdown toggles for nav links

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -108,7 +108,8 @@ export function HeaderMenu({
     handleResize();
     return () => window.removeEventListener('resize', handleResize);
   });
-  
+
+  const enableMobileToggle = windowWidth !== undefined && windowWidth < 500;
 
   return (
     <>
@@ -162,6 +163,7 @@ export function HeaderMenu({
                             menuItems={item}
                             publicStoreDomain={publicStoreDomain}
                             primaryDomainUrl={primaryDomainUrl}
+                            enableMobileToggle={enableMobileToggle}
                           ></AboutDropdown>
                         );
                         break;
@@ -171,6 +173,7 @@ export function HeaderMenu({
                             menuItems={item}
                             publicStoreDomain={publicStoreDomain}
                             primaryDomainUrl={primaryDomainUrl}
+                            enableMobileToggle={enableMobileToggle}
                           ></ServicesDropdown>
                         );
                         break;
@@ -221,6 +224,7 @@ export function HeaderMenu({
                             menuItems={item}
                             publicStoreDomain={publicStoreDomain}
                             primaryDomainUrl={primaryDomainUrl}
+                            enableMobileToggle={enableMobileToggle}
                           ></AboutDropdown>
                         );
                         break;
@@ -230,6 +234,7 @@ export function HeaderMenu({
                             menuItems={item}
                             publicStoreDomain={publicStoreDomain}
                             primaryDomainUrl={primaryDomainUrl}
+                            enableMobileToggle={enableMobileToggle}
                           ></ServicesDropdown>
                         );
                         break;
@@ -315,6 +320,7 @@ export function HeaderMenu({
                             menuItems={item}
                             publicStoreDomain={publicStoreDomain}
                             primaryDomainUrl={primaryDomainUrl}
+                            enableMobileToggle={enableMobileToggle}
                           ></AboutDropdown>
                         );
                         break;
@@ -324,6 +330,7 @@ export function HeaderMenu({
                             menuItems={item}
                             publicStoreDomain={publicStoreDomain}
                             primaryDomainUrl={primaryDomainUrl}
+                            enableMobileToggle={enableMobileToggle}
                           ></ServicesDropdown>
                         );
                         break;
@@ -374,6 +381,7 @@ export function HeaderMenu({
                             menuItems={item}
                             publicStoreDomain={publicStoreDomain}
                             primaryDomainUrl={primaryDomainUrl}
+                            enableMobileToggle={enableMobileToggle}
                           ></AboutDropdown>
                         );
                         break;
@@ -383,6 +391,7 @@ export function HeaderMenu({
                             menuItems={item}
                             publicStoreDomain={publicStoreDomain}
                             primaryDomainUrl={primaryDomainUrl}
+                            enableMobileToggle={enableMobileToggle}
                           ></ServicesDropdown>
                         );
                         break;
@@ -462,6 +471,7 @@ export function HeaderMenu({
                           menuItems={item}
                           publicStoreDomain={publicStoreDomain}
                           primaryDomainUrl={primaryDomainUrl}
+                          enableMobileToggle={enableMobileToggle}
                         />
                       );
                       break;
@@ -472,6 +482,7 @@ export function HeaderMenu({
                           menuItems={item}
                           publicStoreDomain={publicStoreDomain}
                           primaryDomainUrl={primaryDomainUrl}
+                          enableMobileToggle={enableMobileToggle}
                         />
                       );
                       break;
@@ -527,6 +538,7 @@ export function HeaderMenu({
                         menuItems={item}
                         publicStoreDomain={publicStoreDomain}
                         primaryDomainUrl={primaryDomainUrl}
+                        enableMobileToggle={enableMobileToggle}
                       />
                     );
                     break;
@@ -537,6 +549,7 @@ export function HeaderMenu({
                         menuItems={item}
                         publicStoreDomain={publicStoreDomain}
                         primaryDomainUrl={primaryDomainUrl}
+                        enableMobileToggle={enableMobileToggle}
                       />
                     );
                     break;
@@ -607,6 +620,7 @@ export function HeaderMenu({
                         menuItems={item}
                         publicStoreDomain={publicStoreDomain}
                         primaryDomainUrl={primaryDomainUrl}
+                        enableMobileToggle={enableMobileToggle}
                       ></AboutDropdown>
                     );
                     break;
@@ -616,6 +630,7 @@ export function HeaderMenu({
                         menuItems={item}
                         publicStoreDomain={publicStoreDomain}
                         primaryDomainUrl={primaryDomainUrl}
+                        enableMobileToggle={enableMobileToggle}
                       ></ServicesDropdown>
                     );
                     break;
@@ -666,6 +681,7 @@ export function HeaderMenu({
                         menuItems={item}
                         publicStoreDomain={publicStoreDomain}
                         primaryDomainUrl={primaryDomainUrl}
+                        enableMobileToggle={enableMobileToggle}
                       ></AboutDropdown>
                     );
                     break;
@@ -675,6 +691,7 @@ export function HeaderMenu({
                         menuItems={item}
                         publicStoreDomain={publicStoreDomain}
                         primaryDomainUrl={primaryDomainUrl}
+                        enableMobileToggle={enableMobileToggle}
                       ></ServicesDropdown>
                     );
                     break;

--- a/app/components/navbar/AboutDropdown.tsx
+++ b/app/components/navbar/AboutDropdown.tsx
@@ -1,7 +1,8 @@
 // AboutDropdown.tsx (updated)
 import * as RadixHoverCard from '@radix-ui/react-hover-card';
-import {NavLink, Link} from '@remix-run/react';
-import React from 'react';
+import {Link, NavLink} from '@remix-run/react';
+import React, {useEffect, useRef, useState} from 'react';
+import {ChevronUp} from 'lucide-react';
 import {Button} from '../ui/button';
 
 function AboutDropdown({
@@ -12,6 +13,7 @@ function AboutDropdown({
   menuItems: any;
   publicStoreDomain: string;
   primaryDomainUrl: string;
+  enableMobileToggle?: boolean;
 }) {
   const triggerUrl =
     menuItems.url.includes('myshopify.com') ||
@@ -19,6 +21,10 @@ function AboutDropdown({
     menuItems.url.includes(primaryDomainUrl)
       ? new URL(menuItems.url).pathname
       : menuItems.url;
+
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
 
   const writeScrollTarget = (sectionId: string) => {
     try {
@@ -28,27 +34,80 @@ function AboutDropdown({
     }
   };
 
+  useEffect(() => {
+    if (!enableMobileToggle || !open) return;
+
+    const handleClickOutside = (event: MouseEvent | TouchEvent) => {
+      const target = event.target as Node;
+      if (
+        containerRef.current?.contains(target) ||
+        contentRef.current?.contains(target)
+      ) {
+        return;
+      }
+      setOpen(false);
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('touchstart', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('touchstart', handleClickOutside);
+    };
+  }, [enableMobileToggle, open]);
+
   return (
-    <RadixHoverCard.Root openDelay={100} closeDelay={100}>
-      <RadixHoverCard.Trigger asChild>
-        <NavLink
-          to={triggerUrl}
-          className="relative about-dropdown"
-          end
-          prefetch="intent"
-        >
-          <Button
-            variant="ghost2"
-            className="relative group about-dropdown-button py-2 rounded-md transition-colors hover:bg-accent hover:text-primary cursor-pointer"
+    <RadixHoverCard.Root
+      open={open}
+      onOpenChange={setOpen}
+      openDelay={100}
+      closeDelay={100}
+    >
+      <div ref={containerRef} className="flex items-center gap-1">
+        <RadixHoverCard.Trigger asChild>
+          <NavLink
+            to={triggerUrl}
+            className="relative about-dropdown"
+            end
+            prefetch="intent"
           >
-            {menuItems.title}
-            <span className="absolute bottom-0 left-[2px] right-[2px] h-[2px] bg-primary scale-x-0 transition-transform duration-300 group-hover:scale-x-100 origin-center" />
+            <Button
+              variant="ghost2"
+              className="relative group about-dropdown-button py-2 rounded-md transition-colors hover:bg-accent hover:text-primary cursor-pointer"
+            >
+              {menuItems.title}
+              <span className="absolute bottom-0 left-[2px] right-[2px] h-[2px] bg-primary scale-x-0 transition-transform duration-300 group-hover:scale-x-100 origin-center" />
+            </Button>
+          </NavLink>
+        </RadixHoverCard.Trigger>
+
+        {enableMobileToggle && (
+          <Button
+            type="button"
+            variant="ghost2"
+            size="icon"
+            aria-label={`Toggle ${menuItems.title} menu`}
+            aria-expanded={open}
+            className="p-1 h-8 w-8 flex items-center justify-center"
+            onClick={(event) => {
+              event.preventDefault();
+              setOpen((currentOpen) => !currentOpen);
+            }}
+          >
+            <ChevronUp
+              className={`transition-transform duration-200 ${
+                open ? 'rotate-180' : 'rotate-0'
+              }`}
+              size={18}
+            />
           </Button>
-        </NavLink>
-      </RadixHoverCard.Trigger>
+        )}
+      </div>
 
       <RadixHoverCard.Portal>
         <RadixHoverCard.Content
+          ref={contentRef}
           sideOffset={0}
           align="center"
           className="hovercard-content rounded border-l border-r border-t border-b w-[122px]"

--- a/app/components/navbar/ServicesDropdown.tsx
+++ b/app/components/navbar/ServicesDropdown.tsx
@@ -1,7 +1,8 @@
 // ServicesDropdown.tsx (Portal version)
 import * as RadixHoverCard from '@radix-ui/react-hover-card';
-import {NavLink, Link} from '@remix-run/react';
-import React from 'react';
+import {Link, NavLink} from '@remix-run/react';
+import React, {useEffect, useRef, useState} from 'react';
+import {ChevronUp} from 'lucide-react';
 import {Button} from '../ui/button';
 
 function ServicesDropdown({
@@ -12,6 +13,7 @@ function ServicesDropdown({
   menuItems: any;
   publicStoreDomain: string;
   primaryDomainUrl: string;
+  enableMobileToggle?: boolean;
 }) {
   const triggerUrl =
     menuItems.url.includes('myshopify.com') ||
@@ -19,6 +21,10 @@ function ServicesDropdown({
     menuItems.url.includes(primaryDomainUrl)
       ? new URL(menuItems.url).pathname
       : menuItems.url;
+
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const contentRef = useRef<HTMLDivElement>(null);
 
   const writeScrollTarget = (sectionId: string) => {
     try {
@@ -28,27 +34,80 @@ function ServicesDropdown({
     }
   };
 
+  useEffect(() => {
+    if (!enableMobileToggle || !open) return;
+
+    const handleClickOutside = (event: MouseEvent | TouchEvent) => {
+      const target = event.target as Node;
+      if (
+        containerRef.current?.contains(target) ||
+        contentRef.current?.contains(target)
+      ) {
+        return;
+      }
+      setOpen(false);
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    document.addEventListener('touchstart', handleClickOutside);
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+      document.removeEventListener('touchstart', handleClickOutside);
+    };
+  }, [enableMobileToggle, open]);
+
   return (
-    <RadixHoverCard.Root openDelay={100} closeDelay={100}>
-      <RadixHoverCard.Trigger asChild>
-        <NavLink
-          to={triggerUrl}
-          className="relative services-dropdown"
-          end
-          prefetch="intent"
-        >
-          <Button
-            variant="ghost2"
-            className="relative group services-dropdown-button py-2 rounded-md transition-colors hover:bg-accent hover:text-primary cursor-pointer"
+    <RadixHoverCard.Root
+      open={open}
+      onOpenChange={setOpen}
+      openDelay={100}
+      closeDelay={100}
+    >
+      <div ref={containerRef} className="flex items-center gap-1">
+        <RadixHoverCard.Trigger asChild>
+          <NavLink
+            to={triggerUrl}
+            className="relative services-dropdown"
+            end
+            prefetch="intent"
           >
-            {menuItems.title}
-            <span className="absolute bottom-0 left-[2px] right-[2px] h-[2px] bg-primary scale-x-0 transition-transform duration-300 group-hover:scale-x-100 origin-center" />
+            <Button
+              variant="ghost2"
+              className="relative group services-dropdown-button py-2 rounded-md transition-colors hover:bg-accent hover:text-primary cursor-pointer"
+            >
+              {menuItems.title}
+              <span className="absolute bottom-0 left-[2px] right-[2px] h-[2px] bg-primary scale-x-0 transition-transform duration-300 group-hover:scale-x-100 origin-center" />
+            </Button>
+          </NavLink>
+        </RadixHoverCard.Trigger>
+
+        {enableMobileToggle && (
+          <Button
+            type="button"
+            variant="ghost2"
+            size="icon"
+            aria-label={`Toggle ${menuItems.title} menu`}
+            aria-expanded={open}
+            className="p-1 h-8 w-8 flex items-center justify-center"
+            onClick={(event) => {
+              event.preventDefault();
+              setOpen((currentOpen) => !currentOpen);
+            }}
+          >
+            <ChevronUp
+              className={`transition-transform duration-200 ${
+                open ? 'rotate-180' : 'rotate-0'
+              }`}
+              size={18}
+            />
           </Button>
-        </NavLink>
-      </RadixHoverCard.Trigger>
+        )}
+      </div>
 
       <RadixHoverCard.Portal>
         <RadixHoverCard.Content
+          ref={contentRef}
           sideOffset={0}
           align="center"
           className="hovercard-content rounded border-l border-r border-t border-b w-[178px]"


### PR DESCRIPTION
## Summary
- add mobile-only toggle buttons beside About and Services nav links below 500px width
- keep hover behavior while supporting tap-to-open with outside-click closing
- rotate dropdown toggle icons to indicate open/closed state

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69584d7a040c832fa6bf28e867b0245f)