### PR TITLE
Add featured reviews carousel to homepage

### DIFF
--- a/app/components/products/featuredProductReviews.tsx
+++ b/app/components/products/featuredProductReviews.tsx
@@ -1,0 +1,79 @@
+import {Await} from '@remix-run/react';
+import {Suspense} from 'react';
+import ProductReviewsCarousel from '../global/ProductReviewsCarousel';
+import {Separator} from '../ui/separator';
+import type {Review} from '../global/ProductReviewsDisplay';
+
+interface FeaturedReviewsQuery {
+  products: {
+    nodes: Array<{
+      id: string;
+      title: string;
+      metafield?: {
+        value?: string | null;
+      } | null;
+    }>;
+  };
+}
+
+type TaggedReview = Review & {tags?: string[] | string; tag?: string};
+
+const parseTags = (value?: string[] | string) => {
+  if (!value) return [];
+  if (Array.isArray(value)) return value;
+  return value
+    .split(',')
+    .map((tag) => tag.trim())
+    .filter(Boolean);
+};
+
+const isFeaturedReview = (review: TaggedReview) => {
+  const tags = parseTags(review.tags ?? review.tag);
+  return tags.includes('featured');
+};
+
+const parseReviewsValue = (value?: string | null) => {
+  if (!value) return [] as TaggedReview[];
+  try {
+    const parsed = JSON.parse(value) as TaggedReview[];
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [] as TaggedReview[];
+  }
+};
+
+function FeaturedProductReviews({
+  reviews,
+}: {
+  reviews: Promise<FeaturedReviewsQuery | null>;
+}) {
+  return (
+    <>
+      <Separator />
+      <div className="featured-reviews">
+        <Suspense fallback={<div>Loading...</div>}>
+          <Await resolve={reviews}>
+            {(response) => {
+              if (!response) return null;
+              const featuredReviews = response.products.nodes.flatMap((node) =>
+                parseReviewsValue(node.metafield?.value).filter(isFeaturedReview),
+              );
+
+              if (!featuredReviews.length) return null;
+
+              return (
+                <ProductReviewsCarousel
+                  reviews={featuredReviews}
+                  isAdmin={false}
+                />
+              );
+            }}
+          </Await>
+        </Suspense>
+        <br />
+      </div>
+    </>
+  );
+}
+
+export default FeaturedProductReviews;

--- a/app/lib/homeQueries.ts
+++ b/app/lib/homeQueries.ts
@@ -62,6 +62,21 @@ export const RECOMMENDED_PRODUCTS_QUERY = `#graphql
   }
 ` as const;
 
+export const FEATURED_REVIEWS_QUERY = `#graphql
+  query FeaturedReviews($country: CountryCode, $language: LanguageCode)
+    @inContext(country: $country, language: $language) {
+    products(first: 25, sortKey: UPDATED_AT, reverse: true) {
+      nodes {
+        id
+        title
+        metafield(namespace: "custom", key: "reviews") {
+          value
+        }
+      }
+    }
+  }
+` as const;
+
 export const POST_REVIEW_MUTATION = `#graphql 
   mutation MetafieldsSet($metafields: MetafieldsSetInput!) {
   metafieldsSet(metafields: $metafields) {

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -12,9 +12,11 @@ import ProductCarousel from '~/components/products/productCarousel';
 import {
   FEATURED_COLLECTION_QUERY,
   RECOMMENDED_PRODUCTS_QUERY,
+  FEATURED_REVIEWS_QUERY,
 } from '~/lib/homeQueries';
 import RecommendedProducts from '~/components/products/recommendedProducts';
 import {CUSTOMER_WISHLIST} from '~/lib/customerQueries';
+import FeaturedProductReviews from '~/components/products/featuredProductReviews';
 
 export const meta: MetaFunction = () => {
   return [{title: 'Hydrogen | Home'}];
@@ -85,8 +87,16 @@ export function loadDeferredData({context}: LoaderFunctionArgs) {
       return null;
     });
 
+  const featuredReviews = context.storefront
+    .query(FEATURED_REVIEWS_QUERY)
+    .catch((error) => {
+      console.error(error);
+      return null;
+    });
+
   return {
     recommendedProducts,
+    featuredReviews,
   };
 }
 
@@ -116,6 +126,7 @@ export default function Homepage() {
         wishlistProducts={data.wishlistProducts}
         isLoggedIn={data.isLoggedIn}
       />
+      <FeaturedProductReviews reviews={data.featuredReviews} />
     </div>
   );
 }


### PR DESCRIPTION
### Motivation

- Provide a way to mark individual reviews as `featured` and surface them on the homepage.
- Reuse the same strategy as `RecommendedProducts` but for review metafields on products.

### Description

- Added `FEATURED_REVIEWS_QUERY` in `app/lib/homeQueries.ts` to fetch product `reviews` metafields.
- Implemented `FeaturedProductReviews` component at `app/components/products/featuredProductReviews.tsx` which parses product review metafields, filters reviews that include the `featured` tag, and renders them with the existing `ProductReviewsCarousel`.
- Wired the new query and component into the homepage by adding `featuredReviews` to the deferred loader and rendering `<FeaturedProductReviews reviews={data.featuredReviews} />` under `RecommendedProducts` in `app/routes/_index.tsx`.

### Testing

- Started the dev server with `npm run dev -- --host --port 3000`, which launched the Hydrogen dev server (local URL displayed). 
- Attempted to validate the homepage with an automated Playwright screenshot, but loading the page failed with a network error (`ERR_EMPTY_RESPONSE` / MiniOxygen fetch error), so the UI verification could not be completed.
- No unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695da6f17d0c832f8ba9a4aee76a0afe)