### PR TITLE
Add admin-only `isFeatured` flag for product reviews and use it for featured carousel

### DIFF
--- a/app/components/global/AccountReviews.tsx
+++ b/app/components/global/AccountReviews.tsx
@@ -167,7 +167,13 @@ const AccountReviews = ({
 
   const handleEditReview = async (
     entry: UserProductReview,
-    updates: {text: string; title: string; stars: number; image?: File | null},
+    updates: {
+      text: string;
+      title: string;
+      stars: number;
+      image?: File | null;
+      isFeatured?: boolean;
+    },
   ) => {
     if (!customerId || !entry.review?.createdAt) return;
 
@@ -181,6 +187,9 @@ const AccountReviews = ({
     form.append('customerName', customerName ?? '');
     if (updates.image) {
       form.append('image', updates.image);
+    }
+    if (typeof updates.isFeatured === 'boolean') {
+      form.append('isFeatured', updates.isFeatured ? 'yes' : 'no');
     }
 
     try {
@@ -260,6 +269,7 @@ const AccountReviews = ({
               currentCustomerId={customerId ?? undefined}
               onRemove={() => handleRemoveReview(entry)}
               onEdit={(review, update) => handleEditReview(entry, update)}
+              isAdmin={false}
             />
           </div>
         </div>

--- a/app/components/global/ProductReviewsCarousel.tsx
+++ b/app/components/global/ProductReviewsCarousel.tsx
@@ -15,7 +15,13 @@ interface ProductReviewsCarouselProps {
   onRemove?: (review: Review) => Promise<void> | void;
   onEdit?: (
     review: Review,
-    updates: {text: string; title: string; stars: number; image?: File | null},
+    updates: {
+      text: string;
+      title: string;
+      stars: number;
+      image?: File | null;
+      isFeatured?: boolean;
+    },
   ) => Promise<void> | void;
 }
 

--- a/app/components/global/ProductReviewsDisplay.tsx
+++ b/app/components/global/ProductReviewsDisplay.tsx
@@ -17,6 +17,7 @@ export interface Review {
   title?: string;
   customerName?: string;
   customerImage?: string;
+  isFeatured?: boolean;
 }
 
 interface ProductReviewsDisplayProps {
@@ -26,7 +27,13 @@ interface ProductReviewsDisplayProps {
   onRemove?: (review: Review) => Promise<void> | void;
   onEdit?: (
     review: Review,
-    updates: {text: string; title: string; stars: number; image?: File | null},
+    updates: {
+      text: string;
+      title: string;
+      stars: number;
+      image?: File | null;
+      isFeatured?: boolean;
+    },
   ) => Promise<void> | void;
 }
 
@@ -65,6 +72,9 @@ const ProductReviewsDisplay = ({
     displayText.slice(0, REVIEW_CHAR_LIMIT),
   );
   const [editStars, setEditStars] = useState(parsedStars);
+  const [editIsFeatured, setEditIsFeatured] = useState(
+    review.isFeatured ?? false,
+  );
 
   const isCurrentUserReview =
     customerId && resolvedCustomerId && customerId === resolvedCustomerId;
@@ -76,7 +86,14 @@ const ProductReviewsDisplay = ({
     setEditStars(parsedStars);
     setSelectedImage(null);
     setImagePreview(customerImage ?? null);
-  }, [displayTitle, displayText, parsedStars, customerImage]);
+    setEditIsFeatured(review.isFeatured ?? false);
+  }, [
+    displayTitle,
+    displayText,
+    parsedStars,
+    customerImage,
+    review.isFeatured,
+  ]);
 
   const resetEditState = () => {
     setEditTitle(displayTitle);
@@ -84,6 +101,7 @@ const ProductReviewsDisplay = ({
     setEditStars(parsedStars);
     setSelectedImage(null);
     setImagePreview(customerImage ?? null);
+    setEditIsFeatured(review.isFeatured ?? false);
   };
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -113,6 +131,7 @@ const ProductReviewsDisplay = ({
         title: editTitle,
         stars: editStars,
         image: selectedImage,
+        isFeatured: isAdmin ? editIsFeatured : undefined,
       });
       setIsEditing(false);
     } finally {
@@ -138,7 +157,7 @@ const ProductReviewsDisplay = ({
                   </div>
                 </div>
                 <div>
-                  <div className="review-right-side-container">
+                <div className="review-right-side-container">
                     <div className="ps-1 pt-2 pe-2 flex justify-end">
                       <div className="review-right-side">
                         <Button
@@ -169,6 +188,32 @@ const ProductReviewsDisplay = ({
                   </div>
                 </div>
               </div>
+
+              {isAdmin && (
+                <div className="mx-5 mb-4">
+                  <p className="mb-2 font-semibold">isFeatured:</p>
+                  <div className="flex gap-2">
+                    <Button
+                      type="button"
+                      variant={editIsFeatured ? 'default' : 'outline'}
+                      onClick={() => setEditIsFeatured(true)}
+                      disabled={isSaving}
+                      className="cursor-pointer"
+                    >
+                      Yes
+                    </Button>
+                    <Button
+                      type="button"
+                      variant={!editIsFeatured ? 'default' : 'outline'}
+                      onClick={() => setEditIsFeatured(false)}
+                      disabled={isSaving}
+                      className="cursor-pointer"
+                    >
+                      No
+                    </Button>
+                  </div>
+                </div>
+              )}
 
               {imagePreview && (
                 <div className="mt-3 flex justify-center">

--- a/app/components/products/featuredProductReviews.tsx
+++ b/app/components/products/featuredProductReviews.tsx
@@ -16,29 +16,15 @@ interface FeaturedReviewsQuery {
   };
 }
 
-type TaggedReview = Review & {tags?: string[] | string; tag?: string};
-
-const parseTags = (value?: string[] | string) => {
-  if (!value) return [];
-  if (Array.isArray(value)) return value;
-  return value
-    .split(',')
-    .map((tag) => tag.trim())
-    .filter(Boolean);
-};
-
-const isFeaturedReview = (review: TaggedReview) => {
-  const tags = parseTags(review.tags ?? review.tag);
-  return tags.includes('featured');
-};
+type FeaturedReview = Review & {isFeatured?: boolean};
 
 const parseReviewsValue = (value?: string | null) => {
-  if (!value) return [] as TaggedReview[];
+  if (!value) return [] as FeaturedReview[];
   try {
-    const parsed = JSON.parse(value) as TaggedReview[];
+    const parsed = JSON.parse(value) as FeaturedReview[];
     return Array.isArray(parsed) ? parsed : [];
   } catch {
-    return [] as TaggedReview[];
+    return [] as FeaturedReview[];
   }
 };
 
@@ -56,7 +42,9 @@ function FeaturedProductReviews({
             {(response) => {
               if (!response) return null;
               const featuredReviews = response.products.nodes.flatMap((node) =>
-                parseReviewsValue(node.metafield?.value).filter(isFeaturedReview),
+                parseReviewsValue(node.metafield?.value).filter(
+                  (review) => review.isFeatured === true,
+                ),
               );
 
               if (!featuredReviews.length) return null;

--- a/app/routes/api.add_review.ts
+++ b/app/routes/api.add_review.ts
@@ -178,6 +178,7 @@ export async function action({request, context}: ActionFunctionArgs) {
         title,
         customerName,
         customerImage,
+        isFeatured: false,
       },
     ];
 

--- a/app/routes/api.edit_review.tsx
+++ b/app/routes/api.edit_review.tsx
@@ -14,6 +14,7 @@ export async function action({request, context}: ActionFunctionArgs) {
     const customerName = (form.get('customerName') as string) ?? '';
     const createdAt = form.get('createdAt') as string;
     const imageFile = form.get('image') as File | null;
+    const isFeaturedValue = form.get('isFeatured') as string | null;
 
     if (!productId) {
       return json({error: 'Missing productId'}, {status: 400});
@@ -29,6 +30,13 @@ export async function action({request, context}: ActionFunctionArgs) {
     if (!adminToken) {
       return json({error: 'SHOPIFY_ADMIN_TOKEN not found'}, {status: 500});
     }
+
+    const isAdminCustomer =
+      customerId === 'gid://shopify/Customer/7968375079049';
+    const isFeatured =
+      isFeaturedValue === null
+        ? undefined
+        : isFeaturedValue.toLowerCase() === 'yes';
 
     const existingResponse = await fetch(
       `https://${shop}/admin/api/2024-10/graphql.json`,
@@ -121,6 +129,9 @@ export async function action({request, context}: ActionFunctionArgs) {
       title: title || targetReview?.title || '',
       customerName: customerName || targetReview?.customerName || '',
       customerImage: newCustomerImage,
+      isFeatured: isAdminCustomer
+        ? isFeatured ?? targetReview?.isFeatured ?? false
+        : targetReview?.isFeatured ?? false,
       updatedAt: new Date().toISOString(),
     };
 

--- a/app/routes/products.$handle.tsx
+++ b/app/routes/products.$handle.tsx
@@ -739,7 +739,13 @@ export default function Product() {
 
   const handleEditReview = async (
     reviewToEdit: any,
-    updates: {text: string; title: string; stars: number; image?: File | null},
+    updates: {
+      text: string;
+      title: string;
+      stars: number;
+      image?: File | null;
+      isFeatured?: boolean;
+    },
   ) => {
     if (!customerId || !reviewToEdit?.createdAt) return;
 
@@ -753,6 +759,9 @@ export default function Product() {
     form.append('customerName', customerName);
     if (updates.image) {
       form.append('image', updates.image);
+    }
+    if (isAdmin && typeof updates.isFeatured === 'boolean') {
+      form.append('isFeatured', updates.isFeatured ? 'yes' : 'no');
     }
 
     try {


### PR DESCRIPTION
### Motivation
- The existing featured logic relied on a `featured` tag which is not present on review JSON objects, so a different mechanism was needed to mark featured reviews.
- Admins must be able to mark/unmark any review as featured while ordinary users should never see that control.
- Featured reviews should be selected from persisted review data and shown in the homepage carousel.

### Description
- Filter featured reviews by a new `isFeatured` boolean stored in the product reviews JSON and update `app/components/products/featuredProductReviews.tsx` to read `isFeatured` instead of tags.
- Add `isFeatured?: boolean` to the `Review` type and expose an admin-only `isFeatured` toggle in the edit UI inside `app/components/global/ProductReviewsDisplay.tsx` so only admins can flip the flag.
- Wire the flag through edit and creation flows by defaulting new reviews to `isFeatured: false` in `app/routes/api.add_review.ts`, accepting `isFeatured` on edit in `app/routes/api.edit_review.tsx` (but only applying it when the editor is the configured admin), and propagating the value from `products.$handle.tsx` and account review flows.
- Update related types and handlers in `ProductReviewsCarousel`, `AccountReviews`, and product route edit calls so `isFeatured` travels with edits to persistence.

### Testing
- No automated tests were executed as part of this change.
- Manual verification will be required when running the app with an admin account to confirm the toggle appears only for the admin and that the featured carousel displays reviews with `isFeatured: true`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695dac2e0abc832f9db7dae5d89fa6d8)