### PR TITLE
Show homepage video section

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -6,7 +6,6 @@ import type {
   FeaturedCollectionFragment,
   RecommendedProductsQuery,
 } from 'storefrontapi.generated';
-import VideoPreview from '~/components/video/VideoPreview';
 import Hero from '~/components/hero/Hero';
 import ProductCarousel from '~/components/products/productCarousel';
 import {
@@ -138,8 +137,20 @@ export default function Homepage() {
         reviews={data.featuredReviews}
         currentCustomerId={data.currentCustomerId}
       />
-      <video src="https://fpoxvfuxgtlyphowqdgf.supabase.co/storage/v1/object/public/main-bucket/IMG_9152.MOV"></video>
-      <div>hi</div>
+      <section className="home-video">
+        <video
+          className="home-video__player"
+          controls
+          playsInline
+          preload="metadata"
+        >
+          <source
+            src="https://fpoxvfuxgtlyphowqdgf.supabase.co/storage/v1/object/public/main-bucket/IMG_9152.MOV"
+            type="video/quicktime"
+          />
+          Your browser does not support the video tag.
+        </video>
+      </section>
     </div>
   );
 }

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -1613,3 +1613,15 @@ span {
     height: 32px;
   }
 }
+
+.home-video {
+  display: flex;
+  justify-content: center;
+  padding: calc(var(--spacing) * 2) 0;
+}
+
+.home-video__player {
+  width: min(100%, 960px);
+  border-radius: 12px;
+  background: #000;
+}


### PR DESCRIPTION
### Motivation
- The homepage had a bare `<video>` tag that did not display reliably, so the video content was not visible to users.
- The intent is to render the video with proper markup and playback controls so it appears consistently in the UI.
- Remove an unused `VideoPreview` import to clean up the module.

### Description
- Replace the inline bare `<video src=...>` with a semantic section containing a `<video>` player using `controls`, `playsInline`, and `preload="metadata"` and a proper `<source>` element in `app/routes/_index.tsx`.
- Add basic layout and sizing styles for `.home-video` and `.home-video__player` in `app/styles/app.css` to center and constrain the player width.
- Remove the unused `VideoPreview` import from the homepage route to avoid unused imports.

### Testing
- Ran the dev server with `npm run dev -- --port 3000`, but the server encountered MiniOxygen/network errors and dependency resolution warnings and could not remain running (failed).
- Attempted to capture a screenshot via Playwright, but the page navigation failed due to the local server being unreachable (failed).
- No automated tests passed because the development server could not be kept running for verification (no successful automated checks).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696034cab624832f8e7bfb9d5b4108f1)