### PR TITLE
Align review card sections vertically

### DIFF
--- a/app/components/global/ProductReviewsDisplay.tsx
+++ b/app/components/global/ProductReviewsDisplay.tsx
@@ -310,7 +310,7 @@ const ProductReviewsDisplay = ({
       ) : (
         <>
           <div className="review-container">
-            <div className="review-left-side">
+            <div className="review-left-side review-left-side-display">
               {(isCurrentUserReview || isAdmin) && (
                 <>
                   <div className="stars-writtenby-buttons">
@@ -377,36 +377,38 @@ const ProductReviewsDisplay = ({
                   </div>
                 </>
               )}
-              {customerImage && customerVideo ? (
-                <ReviewMediaCarousel url={urls} />
-              ) : (
-                <>
-                  {customerImage && (
-                    <div className="mt-3 mb-5 flex justify-center">
-                      <img
-                        src={customerImage}
-                        alt="Review"
-                        className="max-h-56 rounded object-contain"
-                      />
-                    </div>
-                  )}
-                  {customerVideo && (
-                    <>
-                      <div className="home-video px-2 pt-2">
-                        <video
-                          className="home-video__player"
-                          controls
-                          playsInline
-                          preload="metadata"
-                        >
-                          <source src={customerVideo} type="video/mp4" />
-                        </video>
+              <div className="customer-media-container">
+                {customerImage && customerVideo ? (
+                  <ReviewMediaCarousel url={urls} />
+                ) : (
+                  <>
+                    {customerImage && (
+                      <div className="mt-3 mb-5 flex justify-center">
+                        <img
+                          src={customerImage}
+                          alt="Review"
+                          className="max-h-56 rounded object-contain"
+                        />
                       </div>
-                    </>
-                  )}
-                </>
-              )}
-              <Card className="mt-3 mb-4 mx-4 w-[90%]">
+                    )}
+                    {customerVideo && (
+                      <>
+                        <div className="home-video px-2 pt-2">
+                          <video
+                            className="home-video__player"
+                            controls
+                            playsInline
+                            preload="metadata"
+                          >
+                            <source src={customerVideo} type="video/mp4" />
+                          </video>
+                        </div>
+                      </>
+                    )}
+                  </>
+                )}
+              </div>
+              <Card className="review-summary-card mt-3 mb-4 mx-4 w-[90%]">
                 <CardHeader>
                   <p className="review-title font-bold">{displayTitle}</p>
                 </CardHeader>

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -1257,6 +1257,23 @@ span {
   grid-template-columns: 1fr;
 }
 
+.review-left-side-display {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+.review-left-side-display .review-summary-card {
+  margin-top: auto;
+}
+
+.customer-media-container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  margin: auto 0;
+}
+
 .review-right-side {
   display: grid;
   grid-template-columns: 1fr;


### PR DESCRIPTION
### Motivation
- Reviews currently stack all three left-side elements at the top of each card instead of spacing them vertically.
- The intent is to have the stars/author section pinned to the top, the media perfectly centered, and the review summary pinned to the bottom of each review card.

### Description
- Added `review-left-side-display` to the left column and wrapped media in a `customer-media-container` to provide layout hooks in `ProductReviewsDisplay.tsx`.
- Moved existing media markup into the new `customer-media-container` and renamed the bottom card to `review-summary-card` to allow bottom-alignment.
- Added CSS rules: ` .review-left-side-display` as a column flex container, `.review-left-side-display .review-summary-card { margin-top: auto; }`, and `.customer-media-container { margin: auto 0; align-items: center; }` in `app/styles/app.css` to vertically distribute the three sections.
- Kept existing behavior for admin/current-user buttons and media rendering while only changing layout structure and styles.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961ef39faa8832f92ed19e8313b509c)