### PR TITLE
Add image zoom to review images

### DIFF
--- a/app/components/global/ProductReviewsDisplay.tsx
+++ b/app/components/global/ProductReviewsDisplay.tsx
@@ -6,6 +6,7 @@ import {Button} from '../ui/button';
 import {Input} from '../ui/input';
 import {ReloadIcon} from '@radix-ui/react-icons';
 import ReviewMediaCarousel from './ReviewMediaCarousel';
+import {ImageZoom} from 'components/ui/shadcn-io/image-zoom';
 
 const REVIEW_CHAR_LIMIT = 200;
 
@@ -251,11 +252,13 @@ const ProductReviewsDisplay = ({
 
               {imagePreview && (
                 <div className="mt-3 flex justify-center">
-                  <img
-                    src={imagePreview}
-                    alt="Edited review"
-                    className="max-h-56 rounded object-contain mb-3"
-                  />
+                  <ImageZoom>
+                    <img
+                      src={imagePreview}
+                      alt="Edited review"
+                      className="max-h-56 rounded object-contain mb-3 cursor-zoom-in"
+                    />
+                  </ImageZoom>
                 </div>
               )}
 
@@ -398,11 +401,13 @@ const ProductReviewsDisplay = ({
                   <>
                     {customerImage && (
                       <div className="mb-3 flex justify-center">
-                        <img
-                          src={customerImage}
-                          alt="Review"
-                          className="max-h-56 rounded object-contain"
-                        />
+                        <ImageZoom>
+                          <img
+                            src={customerImage}
+                            alt="Review"
+                            className="max-h-56 rounded object-contain cursor-zoom-in"
+                          />
+                        </ImageZoom>
                       </div>
                     )}
                     {customerVideo && (


### PR DESCRIPTION
### Motivation
- Provide the same click-to-zoom interaction and zoom-in cursor on review images as exists on product carousel images.
- Ensure single-image reviews and edit-preview images can be clicked to open the larger zoom view.

### Description
- Import `ImageZoom` into `app/components/global/ProductReviewsDisplay.tsx`.
- Wrap the edit preview `imagePreview` and single review `customerImage` elements in `<ImageZoom>` and add the `cursor-zoom-in` class to the inner `<img>`.
- No changes were required to `ReviewMediaCarousel.tsx` because its carousel images already use `ImageZoom`.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69646ebcd658832f9a3fdcc6f036851f)