### PR TITLE
Make review media zoom view a navigable carousel (images & videos)

### DIFF
--- a/app/components/global/ReviewMediaCarousel.tsx
+++ b/app/components/global/ReviewMediaCarousel.tsx
@@ -15,7 +15,12 @@ import {
   useNavigate,
 } from '@remix-run/react';
 import {Button} from '../ui/button';
-import {ChevronLeftIcon, ChevronRightIcon, Divide} from 'lucide-react';
+import {
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  Divide,
+  XIcon,
+} from 'lucide-react';
 import {Money} from '@shopify/hydrogen';
 import {useVariantUrl} from '~/lib/variants';
 import {ProductItemFragment, CollectionQuery} from 'storefrontapi.generated';
@@ -33,7 +38,11 @@ import {
 } from '../ui/tooltip';
 import {useIsLoggedIn} from '~/lib/hooks';
 import {toast} from 'sonner';
-import {ImageZoom} from 'components/ui/shadcn-io/image-zoom';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+} from '../ui/dialog';
 
 interface ReviewMedia {
   url: string;
@@ -56,6 +65,12 @@ export const ReviewMediaCarousel = ({
   const [currentIndex, setCurrentIndex] = useState(0);
   const [totalItems, setTotalItems] = useState(0);
   const [windowWidth, setWindowWidth] = useState<number | undefined>(undefined);
+  const [isZoomOpen, setIsZoomOpen] = useState(false);
+  const [zoomIndex, setZoomIndex] = useState(0);
+  const [zoomCarouselApi, setZoomCarouselApi] =
+    useState<CarouselApi | null>(null);
+  const [zoomCurrentIndex, setZoomCurrentIndex] = useState(0);
+  const [zoomTotalItems, setZoomTotalItems] = useState(0);
 
   useEffect(() => {
     function handleResize() {
@@ -81,7 +96,29 @@ export const ReviewMediaCarousel = ({
     return () => void carouselApi.off('select', updateCarouselState);
   }, [carouselApi]);
 
+  useEffect(() => {
+    if (!zoomCarouselApi) return;
+
+    const updateZoomState = () => {
+      setZoomCurrentIndex(zoomCarouselApi.selectedScrollSnap());
+      setZoomTotalItems(zoomCarouselApi.scrollSnapList().length);
+    };
+
+    updateZoomState();
+
+    zoomCarouselApi.on('select', updateZoomState);
+
+    return () => void zoomCarouselApi.off('select', updateZoomState);
+  }, [zoomCarouselApi]);
+
+  useEffect(() => {
+    if (!zoomCarouselApi || !isZoomOpen) return;
+    zoomCarouselApi.scrollTo(zoomIndex, true);
+  }, [zoomCarouselApi, isZoomOpen, zoomIndex]);
+
   const scrollToIndex = (index: number) => carouselApi?.scrollTo(index);
+  const scrollZoomToIndex = (index: number) =>
+    zoomCarouselApi?.scrollTo(index);
   console.log(url, 'url');
 
   const increaseIndex = (evt: React.MouseEvent<HTMLButtonElement>) => {
@@ -92,6 +129,11 @@ export const ReviewMediaCarousel = ({
   const decreaseIndex = (evt: React.MouseEvent<HTMLButtonElement>) => {
     evt.stopPropagation();
     scrollToIndex(currentIndex - 1);
+  };
+
+  const openZoomAtIndex = (index: number) => {
+    setZoomIndex(index);
+    setIsZoomOpen(true);
   };
 
   let locationName: string | undefined;
@@ -122,12 +164,16 @@ export const ReviewMediaCarousel = ({
                         `}
                     >
                       {img.type === 'image' && (
-                        <ImageZoom>
+                        <button
+                          type="button"
+                          onClick={() => openZoomAtIndex(idx)}
+                          className="cursor-zoom-in"
+                        >
                           <img
                             src={img.url}
-                            className={`rounded object-cover transform group-hover:scale-105 transition-transform duration-500 cursor-zoom-in`}
+                            className={`rounded object-cover transform group-hover:scale-105 transition-transform duration-500`}
                           />
-                        </ImageZoom>
+                        </button>
                       )}
                       {img.type === 'video' && (
                         <video
@@ -180,6 +226,88 @@ export const ReviewMediaCarousel = ({
           </div>
         </div>
       </div>
+      <Dialog open={isZoomOpen} onOpenChange={setIsZoomOpen}>
+        <DialogContent className="h-dvh w-dvw max-w-none rounded-none border-0 bg-transparent p-0 shadow-none">
+          <DialogClose className="absolute right-6 top-6 z-20 inline-flex h-10 w-10 items-center justify-center rounded-full bg-black/60 text-white hover:bg-black/80">
+            <XIcon className="h-5 w-5" />
+            <span className="sr-only">Close</span>
+          </DialogClose>
+          <div className="relative z-10 flex h-full w-full items-center justify-center">
+            <div className="relative w-full">
+              <Carousel
+                setApi={setZoomCarouselApi}
+                className="w-full max-w-7xl transform-none"
+              >
+                <CarouselContent>
+                  {url?.map((media, idx) => (
+                    <CarouselItem
+                      className="flex items-center justify-center"
+                      key={`${media.url}-${idx}`}
+                    >
+                      <div className="flex h-full w-full items-center justify-center px-4">
+                        {media.type === 'image' && (
+                          <img
+                            src={media.url}
+                            className="max-h-[80vh] w-auto max-w-[90vw] rounded-lg object-contain"
+                          />
+                        )}
+                        {media.type === 'video' && (
+                          <video
+                            className="max-h-[80vh] w-auto max-w-[90vw] rounded-lg"
+                            controls
+                            playsInline
+                            preload="metadata"
+                          >
+                            <source src={media.url} type="video/mp4" />
+                          </video>
+                        )}
+                      </div>
+                    </CarouselItem>
+                  ))}
+                </CarouselContent>
+                <div className="absolute inset-0 z-20 flex items-center justify-between px-6">
+                  <Button
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      scrollZoomToIndex(zoomCurrentIndex - 1);
+                    }}
+                    className="rounded-full w-10 h-10 p-0 shadow-none bg-white/20 hover:bg-white/30"
+                    variant="secondary"
+                  >
+                    <ChevronLeftIcon className="h-6 w-6 text-white" />
+                  </Button>
+                  <Button
+                    onClick={(event) => {
+                      event.stopPropagation();
+                      scrollZoomToIndex(zoomCurrentIndex + 1);
+                    }}
+                    className="rounded-full w-10 h-10 p-0 shadow-none bg-white/20 hover:bg-white/30"
+                    variant="secondary"
+                  >
+                    <ChevronRightIcon className="h-6 w-6 text-white" />
+                  </Button>
+                </div>
+              </Carousel>
+              {zoomTotalItems > 1 && (
+                <div className="absolute bottom-6 left-0 right-0 z-20 flex items-center justify-center gap-3">
+                  {Array.from({length: zoomTotalItems}).map((_, idx) => (
+                    <button
+                      key={`zoom-dot-${idx}`}
+                      type="button"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        scrollZoomToIndex(idx);
+                      }}
+                      className={`h-2 w-2 rounded-full border border-white/60 ${idx === zoomCurrentIndex ? 'bg-white' : 'bg-white/30'}`}
+                      aria-label={`Go to slide ${idx + 1}`}
+                    />
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </DialogContent>
+      </Dialog>
     </article>
   );
 };


### PR DESCRIPTION
### Motivation
- Allow users to remain in the zoomed review-media view and navigate left/right between all review media items with arrows.
- Make the zoomed view consistent with the `ReviewMediaCarousel` UI by adding dot indicators and arrow navigation.
- Support videos in the zoomed modal so video media from reviews can be viewed inline with images.
- Replace the previous inline `ImageZoom` behavior with a full-screen modal carousel for better UX when inspecting media.

### Description
- Replace inline `ImageZoom` with a `Dialog`-backed carousel and open the dialog at the clicked item using a new `openZoomAtIndex` handler.
- Add modal state and embla API hooks: `isZoomOpen`, `zoomIndex`, `zoomCarouselApi`, `zoomCurrentIndex`, and `zoomTotalItems` to keep selection and dots in sync.
- Add modal navigation controls (left/right arrow `Button`s using `ChevronLeftIcon`/`ChevronRightIcon` and a close `DialogClose` with `XIcon`) and bottom dot indicators that mirror the main carousel.
- Render `video` elements inside the modal carousel so the zoom view supports mixed media (images and videos).

### Testing
- Attempted to run the dev server with `npm run dev -- --port 3000` (and with `--host`), but the local dev server failed to complete startup due to dependency resolution and MiniOxygen network errors. (failed)
- Attempted to capture a UI screenshot with Playwright to validate the modal behavior, but Playwright navigation failed with `net::ERR_EMPTY_RESPONSE` while loading the local site. (failed)
- No automated unit or integration tests were added for this change. 
- The change was lint/compiled locally in the editor and committed, but runtime verification was blocked by the above environment failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696475124684832f9d4816d71f137387)