### PR TITLE
Add top-right close button to zoom modal and center review carousel arrows

### DIFF
--- a/app/components/global/ReviewMediaCarousel.tsx
+++ b/app/components/global/ReviewMediaCarousel.tsx
@@ -265,7 +265,7 @@ export const ReviewMediaCarousel = ({
                     </CarouselItem>
                   ))}
                 </CarouselContent>
-                <div className="absolute inset-0 z-20 flex items-center justify-between px-6">
+                <div className="absolute bottom-6 left-1/2 z-20 flex -translate-x-1/2 items-center gap-4">
                   <Button
                     onClick={(event) => {
                       event.stopPropagation();
@@ -289,7 +289,7 @@ export const ReviewMediaCarousel = ({
                 </div>
               </Carousel>
               {zoomTotalItems > 1 && (
-                <div className="absolute bottom-6 left-0 right-0 z-20 flex items-center justify-center gap-3">
+                <div className="absolute bottom-20 left-0 right-0 z-20 flex items-center justify-center gap-3">
                   {Array.from({length: zoomTotalItems}).map((_, idx) => (
                     <button
                       key={`zoom-dot-${idx}`}

--- a/components/ui/shadcn-io/image-zoom/index.tsx
+++ b/components/ui/shadcn-io/image-zoom/index.tsx
@@ -6,6 +6,7 @@ import Zoom, {
   type UncontrolledProps,
 } from 'react-medium-image-zoom';
 import {cn} from '~/lib/utils';
+import {XIcon} from 'lucide-react';
 
 export type ImageZoomProps = UncontrolledProps & {
   isZoomed?: ControlledProps['isZoomed'];
@@ -62,6 +63,19 @@ export const ImageZoom = ({
         // ✅ This is the key: keeps the zoomed image inset from the viewport edges,
         // which makes it effectively max out at ~90vw/90vh.
         zoomMargin={zoomMargin} // :contentReference[oaicite:1]{index=1}
+        ZoomContent={({img, onUnzoom}) => (
+          <>
+            {img}
+            <button
+              type="button"
+              onClick={onUnzoom}
+              className="absolute right-6 top-6 z-10 inline-flex h-10 w-10 items-center justify-center rounded-full bg-black/60 text-white hover:bg-black/80"
+              aria-label="Close"
+            >
+              <XIcon className="h-5 w-5" />
+            </button>
+          </>
+        )}
         classDialog={cn(
           '[&::backdrop]:hidden',
           // ✅ full viewport dialog => positioning is consistent regardless of scroll


### PR DESCRIPTION
### Motivation
- Provide an explicit close control for zoomed review images so users can dismiss the modal directly.
- Keep zoom navigation unobtrusive by centering arrows and preventing overlap with dot indicators.

### Description
- Added an `XIcon` import and passed a `ZoomContent` render prop into `Zoom` to inject a top-right close button that calls `onUnzoom` in `components/ui/shadcn-io/image-zoom/index.tsx`.
- Styled the close button with `absolute right-6 top-6 z-10 inline-flex h-10 w-10 ...` and added `aria-label="Close"` for accessibility.
- Kept the previously introduced carousel layout changes in `app/components/global/ReviewMediaCarousel.tsx` which center the prev/next buttons using `bottom-6 left-1/2 -translate-x-1/2` and move the dot indicators to `bottom-20` to avoid overlap.

### Testing
- Ran `npm run dev -- --port 3000` to start the dev server, which failed due to dependency resolution and fetch/network errors so the UI could not be loaded.
- Attempted an automated Playwright screenshot run which failed with `net::ERR_EMPTY_RESPONSE`, preventing visual verification.
- No unit or integration tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69647d69c934832fa41a6566cd331e27)