### PR TITLE
Center review media in zoom carousel

### DIFF
--- a/app/components/global/ReviewMediaCarousel.tsx
+++ b/app/components/global/ReviewMediaCarousel.tsx
@@ -217,16 +217,16 @@ export const ReviewMediaCarousel = ({
           </div>
           <div className="flex flex-1 items-center justify-center pb-10">
             <div className="flex w-full max-w-7xl flex-col items-center gap-6">
-              <div className="grid w-full place-items-center">
-                <div className="w-full [grid-column:1] [grid-row:1]">
+              <div className="flex w-full flex-col items-center gap-6">
+                <div className="w-full">
                   <Carousel
                     setApi={setZoomCarouselApi}
                     className="w-full transform-none"
                   >
-                    <CarouselContent>
+                    <CarouselContent className="ml-0">
                       {url?.map((media, idx) => (
                         <CarouselItem
-                          className="flex items-center justify-center"
+                          className="flex items-center justify-center pl-0"
                           key={`${media.url}-${idx}`}
                         >
                           <div className="flex h-full w-full items-center justify-center px-4">
@@ -253,7 +253,7 @@ export const ReviewMediaCarousel = ({
                   </Carousel>
                 </div>
                 {zoomTotalItems > 1 && (
-                  <div className="z-20 flex w-full items-end justify-center gap-3 pb-6 [grid-column:1] [grid-row:1]">
+                  <div className="z-20 flex w-full items-center justify-center gap-3 pb-2">
                     {Array.from({length: zoomTotalItems}).map((_, idx) => (
                       <button
                         key={`zoom-dot-${idx}`}


### PR DESCRIPTION
### Motivation
- Review media slides in the zoom dialog were not visually centered inside the dialog and appeared shifted right. 
- Carousel preview dots were overlaying the media instead of appearing below the currently viewed image/video. 
- The Embla carousel default offset/margins were contributing to the misalignment. 
- Fix layout so each slide and its preview dots are centered and positioned consistently in the dialog view.

### Description
- Replaced grid wrapper with a centered flex column for the zoom dialog to simplify vertical layout and centering. 
- Removed Embla offset/margin from the zoom content by adding `className="ml-0"` to `CarouselContent` and `pl-0` to `CarouselItem`. 
- Moved/adjusted the zoom preview dots container to sit below the media and simplified its spacing by changing classes to `items-center justify-center gap-3 pb-2`. 
- Updated `app/components/global/ReviewMediaCarousel.tsx` to apply these layout changes.

### Testing
- Attempted to run the app with `npm run dev -- --port 3000` to validate visual changes, but the dev server failed to start due to dependency resolution / network fetch errors (missing `@supabase/gotrue-js` in optimizeDeps and undici/miniflare fetch issues). 
- No other automated tests were executed against the modified component due to the failed dev startup.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965caa08b34832f9b892649a57160a4)