### PR TITLE
Show review carousel chevrons centered

### DIFF
--- a/app/components/global/ReviewMediaCarousel.tsx
+++ b/app/components/global/ReviewMediaCarousel.tsx
@@ -171,17 +171,17 @@ export const ReviewMediaCarousel = ({
                 ))}
               </CarouselContent>
 
-              <div className="absolute inset-0 z-40 flex items-center justify-between pointer-events-none">
+              <div className="absolute inset-0 z-40 flex items-center justify-center gap-4 pointer-events-none">
                 <Button
                   onClick={decreaseIndex}
-                  className={`pointer-events-auto rounded-full w-8 h-8 p-0 shadow-none cursor-pointer`}
+                  className={`pointer-events-auto rounded-full w-10 h-10 p-0 shadow-none cursor-pointer bg-black/60 hover:bg-black/75`}
                   variant="secondary"
                 >
                   <ChevronLeftIcon className="h-6 w-6 text-white" />
                 </Button>
                 <Button
                   onClick={increaseIndex}
-                  className={`cursor-pointer pointer-events-auto rounded-full w-8 h-8 p-0 shadow-none`}
+                  className={`cursor-pointer pointer-events-auto rounded-full w-10 h-10 p-0 shadow-none bg-black/60 hover:bg-black/75`}
                   variant="secondary"
                 >
                   <ChevronRightIcon className="h-6 w-6 text-white" />


### PR DESCRIPTION
### Motivation

- The carousel chevron buttons were not visible on the review media carousel and needed to be more prominent for navigation.
- For quick verification the chevrons should be centered over the image so they are immediately visible.

### Description

- Updated `app/components/global/ReviewMediaCarousel.tsx` to center the chevron buttons by changing the container layout to `justify-center` and adding `gap-4`.
- Increased the chevron button size from `w-8 h-8` to `w-10 h-10` and added `bg-black/60 hover:bg-black/75` for better contrast and visibility.
- Kept button click handlers (`decreaseIndex` / `increaseIndex`) and existing `ChevronLeftIcon` / `ChevronRightIcon` usage unchanged.

### Testing

- Launched the dev server with `npm run dev` which reported the app available at `http://localhost:3000/`.
- Attempted an automated Playwright screenshot to validate the visual change but the script failed with `net::ERR_EMPTY_RESPONSE` and could not capture the page.
- No other automated tests were executed for this visual-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6965d09d3f20832f8be4f02aa317611c)