### PR TITLE
Refine review carousel dialog layout and per-dialog overlay styling

### DIFF
--- a/app/components/global/ReviewMediaCarousel.tsx
+++ b/app/components/global/ReviewMediaCarousel.tsx
@@ -208,17 +208,20 @@ export const ReviewMediaCarousel = ({
         </div>
       </div>
       <Dialog open={isZoomOpen} onOpenChange={setIsZoomOpen}>
-        <DialogContent className="flex h-dvh w-dvw max-w-none flex-col rounded-none border-0 bg-transparent p-0 shadow-none">
-          <div className="flex w-full items-start justify-end p-6">
-            <DialogClose className="inline-flex h-10 w-10 items-center justify-center rounded-md border cursor-pointer text-white hover:bg-black/80">
-              <XIcon className="h-5 w-5" />
-              <span className="sr-only">Close</span>
-            </DialogClose>
-          </div>
-          <div className="flex flex-1 items-center justify-center pb-10">
-            <div className="flex w-full max-w-7xl flex-col items-center gap-6">
-              <div className="flex w-full flex-col items-center gap-6">
-                <div className="relative w-full">
+        <DialogContent
+          overlayClassName="bg-background/80 backdrop-blur-md transition-all"
+          className="flex h-dvh w-dvw max-w-none flex-col rounded-none border-0 bg-transparent p-0 shadow-none top-0 left-0 translate-x-0 translate-y-0"
+        >
+          <div className="flex h-full w-full flex-col gap-6 p-[3vw]">
+            <div className="flex w-full items-start justify-end">
+              <DialogClose className="inline-flex h-10 w-10 items-center justify-center rounded-md border cursor-pointer text-white hover:bg-black/80">
+                <XIcon className="h-5 w-5" />
+                <span className="sr-only">Close</span>
+              </DialogClose>
+            </div>
+            <div className="flex flex-1 items-center justify-center">
+              <div className="flex w-full max-w-7xl flex-col items-center gap-6">
+                <div className="w-full">
                   <Carousel
                     setApi={setZoomCarouselApi}
                     className="w-full transform-none"
@@ -233,12 +236,12 @@ export const ReviewMediaCarousel = ({
                             {media.type === 'image' && (
                               <img
                                 src={media.url}
-                                className="max-h-[80vh] w-auto max-w-[90vw] rounded-lg object-contain"
+                                className="max-h-[calc(100vh-12rem)] w-auto max-w-[90vw] rounded-lg object-contain"
                               />
                             )}
                             {media.type === 'video' && (
                               <video
-                                className="max-h-[80vh] w-auto max-w-[90vw] rounded-lg"
+                                className="max-h-[calc(100vh-12rem)] w-auto max-w-[90vw] rounded-lg"
                                 controls
                                 playsInline
                                 preload="metadata"
@@ -251,14 +254,16 @@ export const ReviewMediaCarousel = ({
                       ))}
                     </CarouselContent>
                   </Carousel>
-                  {zoomTotalItems > 1 && (
-                    <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center gap-4">
+                </div>
+                {zoomTotalItems > 1 && (
+                  <>
+                    <div className="flex w-full items-center justify-center gap-4">
                       <Button
                         onClick={(event) => {
                           event.stopPropagation();
                           scrollZoomToIndex(zoomCurrentIndex - 1);
                         }}
-                        className="pointer-events-auto rounded-full w-10 h-10 p-0 shadow-none bg-black/60 hover:bg-black/75"
+                        className="rounded-full w-10 h-10 p-0 shadow-none bg-black/60 hover:bg-black/75"
                         variant="secondary"
                       >
                         <ChevronLeftIcon className="h-6 w-6 text-white" />
@@ -268,29 +273,27 @@ export const ReviewMediaCarousel = ({
                           event.stopPropagation();
                           scrollZoomToIndex(zoomCurrentIndex + 1);
                         }}
-                        className="pointer-events-auto rounded-full w-10 h-10 p-0 shadow-none bg-black/60 hover:bg-black/75"
+                        className="rounded-full w-10 h-10 p-0 shadow-none bg-black/60 hover:bg-black/75"
                         variant="secondary"
                       >
                         <ChevronRightIcon className="h-6 w-6 text-white" />
                       </Button>
                     </div>
-                  )}
-                </div>
-                {zoomTotalItems > 1 && (
-                  <div className="z-20 flex w-full items-center justify-center gap-3 pb-2">
-                    {Array.from({length: zoomTotalItems}).map((_, idx) => (
-                      <button
-                        key={`zoom-dot-${idx}`}
-                        type="button"
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          scrollZoomToIndex(idx);
-                        }}
-                        className={`h-2 w-2 rounded-full border border-white/60 ${idx === zoomCurrentIndex ? 'bg-white' : 'bg-white/30'}`}
-                        aria-label={`Go to slide ${idx + 1}`}
-                      />
-                    ))}
-                  </div>
+                    <div className="z-20 flex w-full items-center justify-center gap-3 pb-2">
+                      {Array.from({length: zoomTotalItems}).map((_, idx) => (
+                        <button
+                          key={`zoom-dot-${idx}`}
+                          type="button"
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            scrollZoomToIndex(idx);
+                          }}
+                          className={`h-2 w-2 rounded-full border border-white/60 ${idx === zoomCurrentIndex ? 'bg-white' : 'bg-white/30'}`}
+                          aria-label={`Go to slide ${idx + 1}`}
+                        />
+                      ))}
+                    </div>
+                  </>
                 )}
               </div>
             </div>

--- a/app/components/ui/dialog.tsx
+++ b/app/components/ui/dialog.tsx
@@ -34,7 +34,7 @@ function DialogOverlay({
     <DialogPrimitive.Overlay
       data-slot="dialog-overlay"
       className={cn(
-        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50',
+        'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-[1000] bg-black/50',
         className,
       )}
       {...props}
@@ -46,17 +46,19 @@ function DialogContent({
   className,
   children,
   showCloseButton = true,
+  overlayClassName,
   ...props
 }: React.ComponentProps<typeof DialogPrimitive.Content> & {
   showCloseButton?: boolean;
+  overlayClassName?: string;
 }) {
   return (
     <DialogPortal data-slot="dialog-portal">
-      <DialogOverlay />
+      <DialogOverlay className={overlayClassName} />
       <DialogPrimitive.Content
         data-slot="dialog-content"
         className={cn(
-          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 w-[80%]',
+          'bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-[1000] grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 w-[80%]',
           className,
         )}
         {...props}


### PR DESCRIPTION
### Motivation
- Prevent the review carousel modal from overflowing the viewport and make its spacing, overlay, and transitions match the single-image zoom presentation.
- Allow dialogs to opt into the blurred/translucent overlay used by the single-image zoom so different dialogs can have distinct overlay styling.

### Description
- Add `overlayClassName` prop to `DialogContent` and forward it into `DialogOverlay` so callers can provide per-dialog overlay classes (`app/components/ui/dialog.tsx`).
- Increase dialog overlay/content stacking to `z-[1000]` to keep overlay/content above page elements and allow overlay styling to apply cleanly (`app/components/ui/dialog.tsx`).
- Rework the review carousel dialog layout to mirror single-image zoom spacing by moving padding into an inner container, aligning the close button, and preventing viewport overflow (`app/components/global/ReviewMediaCarousel.tsx`).
- Adjust media max-height to `max-h-[calc(100vh-12rem)]` to leave consistent spacing above/below the image/video, move carousel arrows to sit beneath the media, and keep the white preview dots visible below the arrows (`app/components/global/ReviewMediaCarousel.tsx`).

### Testing
- Ran the dev server with `npm run dev -- --host --port 3000`, which started but encountered runtime network issues (MiniOxygen: "Network connection lost") and ultimately failed to complete visual verification.
- No automated unit or snapshot tests were added or executed for these UI changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c6d8421bc832f846520e1a1efe32f)