### PR TITLE
Add CarouselZoom component and integrate with ReviewMediaCarousel

### DIFF
--- a/app/components/global/ProductReviewsDisplay.tsx
+++ b/app/components/global/ProductReviewsDisplay.tsx
@@ -6,6 +6,7 @@ import {Button} from '../ui/button';
 import {Input} from '../ui/input';
 import {ReloadIcon} from '@radix-ui/react-icons';
 import ReviewMediaCarousel from './ReviewMediaCarousel';
+import {CarouselZoom} from 'components/ui/shadcn-io/carousel-zoom';
 import {ImageZoom} from 'components/ui/shadcn-io/image-zoom';
 
 const REVIEW_CHAR_LIMIT = 200;
@@ -394,9 +395,16 @@ const ProductReviewsDisplay = ({
                   </div>
                 </>
               )}
-              <div className="customer-media-container">
+                <div className="customer-media-container">
                 {customerImage && customerVideo ? (
-                  <ReviewMediaCarousel url={urls} />
+                  <CarouselZoom items={urls}>
+                    {(openAtIndex) => (
+                      <ReviewMediaCarousel
+                        url={urls}
+                        onImageClick={openAtIndex}
+                      />
+                    )}
+                  </CarouselZoom>
                 ) : (
                   <>
                     {customerImage && (

--- a/app/components/global/ReviewMediaCarousel.tsx
+++ b/app/components/global/ReviewMediaCarousel.tsx
@@ -1,39 +1,14 @@
 // app/components/productCarousel.tsx
 import React, {useEffect, useState} from 'react';
-import {Card, CardContent} from '../ui/card';
 import {
   Carousel,
+  CarouselApi,
   CarouselContent,
   CarouselItem,
-  CarouselApi,
 } from '../ui/carousel';
-import {
-  Link,
-  NavLink,
-  Navigate,
-  useLoaderData,
-  useNavigate,
-} from '@remix-run/react';
 import {Button} from '../ui/button';
-import {ChevronLeftIcon, ChevronRightIcon, Divide, XIcon} from 'lucide-react';
-import {Money} from '@shopify/hydrogen';
-import {useVariantUrl} from '~/lib/variants';
-import {ProductItemFragment, CollectionQuery} from 'storefrontapi.generated';
-import {PartialPredictiveSearchResult} from '../SearchResultsPredictive';
-import {CurrencyCode} from '@shopify/hydrogen/storefront-api-types';
+import {ChevronLeftIcon, ChevronRightIcon} from 'lucide-react';
 import '../../styles/routeStyles/product.css';
-import {LoaderFunctionArgs, redirect} from '@remix-run/server-runtime';
-import {ReloadIcon} from '@radix-ui/react-icons';
-import {FaHeart, FaRegHeart} from 'react-icons/fa';
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '../ui/tooltip';
-import {useIsLoggedIn} from '~/lib/hooks';
-import {toast} from 'sonner';
-import {Dialog, DialogClose, DialogContent} from '../ui/dialog';
 
 interface ReviewMedia {
   url: string;
@@ -42,26 +17,20 @@ interface ReviewMedia {
 
 export const ReviewMediaCarousel = ({
   url,
+  onImageClick,
 }: {
   // accept full product OR a looser shape (to silence type-checking when your caller doesn't have full objects)
   url: ReviewMedia[];
+  onImageClick?: (index: number) => void;
 }) => {
   const cardClassName =
     'group-hover:shadow-xl h-full transition-shadow duration-500 cursor-pointer';
 
   const cardContentClassName = 'flex flex-col h-full';
 
-  const navigate = useNavigate();
   const [carouselApi, setCarouselApi] = useState<CarouselApi | null>(null);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [totalItems, setTotalItems] = useState(0);
-  const [isZoomOpen, setIsZoomOpen] = useState(false);
-  const [zoomIndex, setZoomIndex] = useState(0);
-  const [zoomCarouselApi, setZoomCarouselApi] = useState<CarouselApi | null>(
-    null,
-  );
-  const [zoomCurrentIndex, setZoomCurrentIndex] = useState(0);
-  const [zoomTotalItems, setZoomTotalItems] = useState(0);
 
   useEffect(() => {
     if (!carouselApi) return;
@@ -78,29 +47,7 @@ export const ReviewMediaCarousel = ({
     return () => void carouselApi.off('select', updateCarouselState);
   }, [carouselApi]);
 
-  useEffect(() => {
-    if (!zoomCarouselApi) return;
-
-    const updateZoomState = () => {
-      setZoomCurrentIndex(zoomCarouselApi.selectedScrollSnap());
-      setZoomTotalItems(zoomCarouselApi.scrollSnapList().length);
-    };
-
-    updateZoomState();
-
-    zoomCarouselApi.on('select', updateZoomState);
-
-    return () => void zoomCarouselApi.off('select', updateZoomState);
-  }, [zoomCarouselApi]);
-
-  useEffect(() => {
-    if (!zoomCarouselApi || !isZoomOpen) return;
-    zoomCarouselApi.scrollTo(zoomIndex, true);
-  }, [zoomCarouselApi, isZoomOpen, zoomIndex]);
-
   const scrollToIndex = (index: number) => carouselApi?.scrollTo(index);
-  const scrollZoomToIndex = (index: number) => zoomCarouselApi?.scrollTo(index);
-  console.log(url, 'url');
 
   const increaseIndex = (evt: React.MouseEvent<HTMLButtonElement>) => {
     evt.stopPropagation();
@@ -111,18 +58,6 @@ export const ReviewMediaCarousel = ({
     evt.stopPropagation();
     scrollToIndex(currentIndex - 1);
   };
-
-  const openZoomAtIndex = (index: number) => {
-    setZoomIndex(index);
-    setIsZoomOpen(true);
-  };
-
-  let locationName: string | undefined;
-  let locationState: string | undefined;
-  let locationCountry: string | undefined;
-
-  const titleCase = (w: string) =>
-    w.length === 0 ? w : w.charAt(0).toUpperCase() + w.slice(1).toLowerCase();
 
   return (
     <article className="group relative">
@@ -147,7 +82,7 @@ export const ReviewMediaCarousel = ({
                       {img.type === 'image' && (
                         <button
                           type="button"
-                          onClick={() => openZoomAtIndex(idx)}
+                          onClick={() => onImageClick?.(idx)}
                           className="cursor-zoom-in"
                         >
                           <img
@@ -207,96 +142,6 @@ export const ReviewMediaCarousel = ({
           </div>
         </div>
       </div>
-      <Dialog open={isZoomOpen} onOpenChange={setIsZoomOpen}>
-        <DialogContent className="flex h-dvh w-dvw max-w-none flex-col rounded-none border-0 bg-transparent p-0 shadow-none">
-          <div className="flex w-full items-start justify-end p-6">
-            <DialogClose className="inline-flex h-10 w-10 items-center justify-center rounded-md border cursor-pointer text-white hover:bg-black/80">
-              <XIcon className="h-5 w-5" />
-              <span className="sr-only">Close</span>
-            </DialogClose>
-          </div>
-          <div className="flex flex-1 items-center justify-center pb-10">
-            <div className="flex w-full max-w-7xl flex-col items-center gap-6">
-              <div className="flex w-full flex-col items-center gap-6">
-                <div className="relative w-full">
-                  <Carousel
-                    setApi={setZoomCarouselApi}
-                    className="w-full transform-none"
-                  >
-                    <CarouselContent className="ml-0">
-                      {url?.map((media, idx) => (
-                        <CarouselItem
-                          className="flex items-center justify-center pl-0"
-                          key={`${media.url}-${idx}`}
-                        >
-                          <div className="flex h-full w-full items-center justify-center px-4">
-                            {media.type === 'image' && (
-                              <img
-                                src={media.url}
-                                className="max-h-[80vh] w-auto max-w-[90vw] rounded-lg object-contain"
-                              />
-                            )}
-                            {media.type === 'video' && (
-                              <video
-                                className="max-h-[80vh] w-auto max-w-[90vw] rounded-lg"
-                                controls
-                                playsInline
-                                preload="metadata"
-                              >
-                                <source src={media.url} type="video/mp4" />
-                              </video>
-                            )}
-                          </div>
-                        </CarouselItem>
-                      ))}
-                    </CarouselContent>
-                  </Carousel>
-                  {zoomTotalItems > 1 && (
-                    <div className="pointer-events-none absolute inset-0 z-20 flex items-center justify-center gap-4">
-                      <Button
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          scrollZoomToIndex(zoomCurrentIndex - 1);
-                        }}
-                        className="pointer-events-auto rounded-full w-10 h-10 p-0 shadow-none bg-black/60 hover:bg-black/75"
-                        variant="secondary"
-                      >
-                        <ChevronLeftIcon className="h-6 w-6 text-white" />
-                      </Button>
-                      <Button
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          scrollZoomToIndex(zoomCurrentIndex + 1);
-                        }}
-                        className="pointer-events-auto rounded-full w-10 h-10 p-0 shadow-none bg-black/60 hover:bg-black/75"
-                        variant="secondary"
-                      >
-                        <ChevronRightIcon className="h-6 w-6 text-white" />
-                      </Button>
-                    </div>
-                  )}
-                </div>
-                {zoomTotalItems > 1 && (
-                  <div className="z-20 flex w-full items-center justify-center gap-3 pb-2">
-                    {Array.from({length: zoomTotalItems}).map((_, idx) => (
-                      <button
-                        key={`zoom-dot-${idx}`}
-                        type="button"
-                        onClick={(event) => {
-                          event.stopPropagation();
-                          scrollZoomToIndex(idx);
-                        }}
-                        className={`h-2 w-2 rounded-full border border-white/60 ${idx === zoomCurrentIndex ? 'bg-white' : 'bg-white/30'}`}
-                        aria-label={`Go to slide ${idx + 1}`}
-                      />
-                    ))}
-                  </div>
-                )}
-              </div>
-            </div>
-          </div>
-        </DialogContent>
-      </Dialog>
     </article>
   );
 };

--- a/components/ui/shadcn-io/carousel-zoom/index.tsx
+++ b/components/ui/shadcn-io/carousel-zoom/index.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import * as React from 'react';
+import * as DialogPrimitive from '@radix-ui/react-dialog';
+import {ChevronLeftIcon, ChevronRightIcon, XIcon} from 'lucide-react';
+import {
+  Carousel,
+  CarouselApi,
+  CarouselContent,
+  CarouselItem,
+} from '~/components/ui/carousel';
+import {Button} from '~/components/ui/button';
+import {
+  Dialog,
+  DialogClose,
+  DialogOverlay,
+  DialogPortal,
+} from '~/components/ui/dialog';
+import {cn} from '~/lib/utils';
+
+type CarouselZoomItem = {
+  url: string;
+  type: string;
+};
+
+export type CarouselZoomProps = {
+  items: CarouselZoomItem[];
+  children: (openAtIndex: (index: number) => void) => React.ReactNode;
+};
+
+export const CarouselZoom = ({items, children}: CarouselZoomProps) => {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [zoomIndex, setZoomIndex] = React.useState(0);
+  const [zoomCarouselApi, setZoomCarouselApi] = React.useState<CarouselApi | null>(
+    null,
+  );
+  const [zoomCurrentIndex, setZoomCurrentIndex] = React.useState(0);
+  const [zoomTotalItems, setZoomTotalItems] = React.useState(0);
+
+  React.useEffect(() => {
+    if (!zoomCarouselApi) return;
+
+    const updateZoomState = () => {
+      setZoomCurrentIndex(zoomCarouselApi.selectedScrollSnap());
+      setZoomTotalItems(zoomCarouselApi.scrollSnapList().length);
+    };
+
+    updateZoomState();
+    zoomCarouselApi.on('select', updateZoomState);
+
+    return () => void zoomCarouselApi.off('select', updateZoomState);
+  }, [zoomCarouselApi]);
+
+  React.useEffect(() => {
+    if (!zoomCarouselApi || !isOpen) return;
+    zoomCarouselApi.scrollTo(zoomIndex, true);
+  }, [zoomCarouselApi, isOpen, zoomIndex]);
+
+  const openAtIndex = (index: number) => {
+    setZoomIndex(index);
+    setIsOpen(true);
+  };
+
+  const scrollZoomToIndex = (index: number) => zoomCarouselApi?.scrollTo(index);
+
+  return (
+    <>
+      {children(openAtIndex)}
+      <Dialog open={isOpen} onOpenChange={setIsOpen}>
+        <DialogPortal>
+          <DialogOverlay className="bg-background/80 backdrop-blur-md" />
+          <DialogPrimitive.Content
+            className={cn(
+              'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed inset-0 z-50 flex h-dvh w-dvw flex-col bg-transparent p-0 shadow-none duration-200',
+            )}
+          >
+            <div className="flex h-full w-full flex-col gap-6 p-[3vw]">
+              <div className="flex w-full items-start justify-end">
+                <DialogClose className="inline-flex h-10 w-10 items-center justify-center rounded-md border cursor-pointer text-white hover:bg-black/80">
+                  <XIcon className="h-5 w-5" />
+                  <span className="sr-only">Close</span>
+                </DialogClose>
+              </div>
+              <div className="flex flex-1 items-center justify-center">
+                <div className="flex w-full max-w-7xl flex-col items-center gap-6">
+                  <div className="w-full">
+                    <Carousel setApi={setZoomCarouselApi} className="w-full transform-none">
+                      <CarouselContent className="ml-0">
+                        {items?.map((media, idx) => (
+                          <CarouselItem
+                            className="flex items-center justify-center pl-0"
+                            key={`${media.url}-${idx}`}
+                          >
+                            <div className="flex h-full w-full items-center justify-center px-4">
+                              {media.type === 'image' && (
+                                <img
+                                  src={media.url}
+                                  className="max-h-[calc(100vh-12rem)] w-auto max-w-[90vw] rounded-lg object-contain"
+                                />
+                              )}
+                              {media.type === 'video' && (
+                                <video
+                                  className="max-h-[calc(100vh-12rem)] w-auto max-w-[90vw] rounded-lg"
+                                  controls
+                                  playsInline
+                                  preload="metadata"
+                                >
+                                  <source src={media.url} type="video/mp4" />
+                                </video>
+                              )}
+                            </div>
+                          </CarouselItem>
+                        ))}
+                      </CarouselContent>
+                    </Carousel>
+                  </div>
+                  {zoomTotalItems > 1 && (
+                    <div className="flex flex-col items-center gap-4">
+                      <div className="z-20 flex w-full items-center justify-center gap-3">
+                        {Array.from({length: zoomTotalItems}).map((_, idx) => (
+                          <button
+                            key={`zoom-dot-${idx}`}
+                            type="button"
+                            onClick={(event) => {
+                              event.stopPropagation();
+                              scrollZoomToIndex(idx);
+                            }}
+                            className={`h-2 w-2 rounded-full border border-white/60 ${idx === zoomCurrentIndex ? 'bg-white' : 'bg-white/30'}`}
+                            aria-label={`Go to slide ${idx + 1}`}
+                          />
+                        ))}
+                      </div>
+                      <div className="flex w-full items-center justify-center gap-4">
+                        <Button
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            scrollZoomToIndex(zoomCurrentIndex - 1);
+                          }}
+                          className="rounded-full w-10 h-10 p-0 shadow-none bg-black/60 hover:bg-black/75"
+                          variant="secondary"
+                        >
+                          <ChevronLeftIcon className="h-6 w-6 text-white" />
+                        </Button>
+                        <Button
+                          onClick={(event) => {
+                            event.stopPropagation();
+                            scrollZoomToIndex(zoomCurrentIndex + 1);
+                          }}
+                          className="rounded-full w-10 h-10 p-0 shadow-none bg-black/60 hover:bg-black/75"
+                          variant="secondary"
+                        >
+                          <ChevronRightIcon className="h-6 w-6 text-white" />
+                        </Button>
+                      </div>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          </DialogPrimitive.Content>
+        </DialogPortal>
+      </Dialog>
+    </>
+  );
+};


### PR DESCRIPTION
### Motivation
- Provide an ImageZoom-like modal that can show a carousel containing images and videos with preview dots, navigation arrows beneath the dots, and a close (`X`) control so multi-media review carousels can be zoomed in-place.
- Reuse a single modal wrapper for review carousels instead of keeping per-carousel zoom logic to simplify code and keep the modal overlay/spacing consistent with existing `ImageZoom` behavior.
- Prevent duplication of zoom/dialog state across components by delegating zoom activation to a wrapper component via a callback.

### Description
- Add `CarouselZoom` component at `components/ui/shadcn-io/carousel-zoom/index.tsx` that opens a modal dialog with a blurred/translucent overlay, an `X` close button, preview dots centered under the media, and previous/next arrow buttons placed below the dots; the dialog uses the existing `Carousel` API and scrolls to the requested slide on open.
- Refactor `ReviewMediaCarousel` (`app/components/global/ReviewMediaCarousel.tsx`) to accept an optional `onImageClick` callback and remove its internal zoom/dialog logic so it only renders the inline carousel and preview dots/overlay arrows.
- Wrap `ReviewMediaCarousel` instances in `ProductReviewsDisplay` (`app/components/global/ProductReviewsDisplay.tsx`) with `CarouselZoom` so review media open in the new modal when clicked, and use `max-h-[calc(100vh-12rem)]` sizing in the modal for consistent top/bottom spacing.
- Clean up related imports and remove now-unused zoom state/code from the carousel component.

### Testing
- Ran the dev server with `npm run dev -- --host --port 3000`, but the run failed due to MiniOxygen network/`fetch` errors (network connection lost), preventing visual verification of the modal behavior.
- No automated unit or snapshot tests were added or executed for these UI changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c6d8421bc832f846520e1a1efe32f)