### PR TITLE
Match carousel zoom transitions to image zoom

### DIFF
--- a/components/ui/shadcn-io/carousel-zoom/index.tsx
+++ b/components/ui/shadcn-io/carousel-zoom/index.tsx
@@ -68,15 +68,15 @@ export const CarouselZoom = ({items, children}: CarouselZoomProps) => {
       {children(openAtIndex)}
       <Dialog open={isOpen} onOpenChange={setIsOpen}>
         <DialogPortal>
-          <DialogOverlay className="bg-background/80 backdrop-blur-md" />
+          <DialogOverlay className="transition-all data-[state=closed]:bg-transparent data-[state=closed]:backdrop-blur-0 data-[state=open]:bg-background/80 data-[state=open]:backdrop-blur-md motion-reduce:transition-none" />
           <DialogPrimitive.Content
             className={cn(
-              'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed inset-0 z-50 flex h-dvh w-dvw flex-col bg-transparent p-0 shadow-none duration-200',
+              'data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed inset-0 z-[1001] flex h-dvh w-dvw flex-col bg-transparent p-0 shadow-none duration-200 motion-reduce:animate-none',
             )}
           >
             <div className="flex h-full w-full flex-col gap-6 p-[3vw]">
               <div className="flex w-full items-start justify-end">
-                <DialogClose className="inline-flex h-10 w-10 items-center justify-center rounded-md border cursor-pointer text-white hover:bg-black/80">
+                <DialogClose className="inline-flex h-10 w-10 items-center justify-center rounded-full bg-black/60 text-white hover:bg-black/80">
                   <XIcon className="h-5 w-5" />
                   <span className="sr-only">Close</span>
                 </DialogClose>
@@ -84,7 +84,10 @@ export const CarouselZoom = ({items, children}: CarouselZoomProps) => {
               <div className="flex flex-1 items-center justify-center">
                 <div className="flex w-full max-w-7xl flex-col items-center gap-6">
                   <div className="w-full">
-                    <Carousel setApi={setZoomCarouselApi} className="w-full transform-none">
+                    <Carousel
+                      setApi={setZoomCarouselApi}
+                      className="w-full transform-none"
+                    >
                       <CarouselContent className="ml-0">
                         {items?.map((media, idx) => (
                           <CarouselItem
@@ -114,48 +117,48 @@ export const CarouselZoom = ({items, children}: CarouselZoomProps) => {
                       </CarouselContent>
                     </Carousel>
                   </div>
-                  {zoomTotalItems > 1 && (
-                    <div className="flex flex-col items-center gap-4">
-                      <div className="z-20 flex w-full items-center justify-center gap-3">
-                        {Array.from({length: zoomTotalItems}).map((_, idx) => (
-                          <button
-                            key={`zoom-dot-${idx}`}
-                            type="button"
-                            onClick={(event) => {
-                              event.stopPropagation();
-                              scrollZoomToIndex(idx);
-                            }}
-                            className={`h-2 w-2 rounded-full border border-white/60 ${idx === zoomCurrentIndex ? 'bg-white' : 'bg-white/30'}`}
-                            aria-label={`Go to slide ${idx + 1}`}
-                          />
-                        ))}
-                      </div>
-                      <div className="flex w-full items-center justify-center gap-4">
-                        <Button
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            scrollZoomToIndex(zoomCurrentIndex - 1);
-                          }}
-                          className="rounded-full w-10 h-10 p-0 shadow-none bg-black/60 hover:bg-black/75"
-                          variant="secondary"
-                        >
-                          <ChevronLeftIcon className="h-6 w-6 text-white" />
-                        </Button>
-                        <Button
-                          onClick={(event) => {
-                            event.stopPropagation();
-                            scrollZoomToIndex(zoomCurrentIndex + 1);
-                          }}
-                          className="rounded-full w-10 h-10 p-0 shadow-none bg-black/60 hover:bg-black/75"
-                          variant="secondary"
-                        >
-                          <ChevronRightIcon className="h-6 w-6 text-white" />
-                        </Button>
-                      </div>
-                    </div>
-                  )}
                 </div>
               </div>
+              {zoomTotalItems > 1 && (
+                <div className="flex flex-col items-center gap-3 pb-6">
+                  <div className="flex w-full items-center justify-center gap-4">
+                    <Button
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        scrollZoomToIndex(zoomCurrentIndex - 1);
+                      }}
+                      className="rounded-full w-10 h-10 p-0 shadow-none bg-black/60 hover:bg-black/75"
+                      variant="secondary"
+                    >
+                      <ChevronLeftIcon className="h-6 w-6 text-white" />
+                    </Button>
+                    <Button
+                      onClick={(event) => {
+                        event.stopPropagation();
+                        scrollZoomToIndex(zoomCurrentIndex + 1);
+                      }}
+                      className="rounded-full w-10 h-10 p-0 shadow-none bg-black/60 hover:bg-black/75"
+                      variant="secondary"
+                    >
+                      <ChevronRightIcon className="h-6 w-6 text-white" />
+                    </Button>
+                  </div>
+                  <div className="z-20 flex w-full items-center justify-center gap-3">
+                    {Array.from({length: zoomTotalItems}).map((_, idx) => (
+                      <button
+                        key={`zoom-dot-${idx}`}
+                        type="button"
+                        onClick={(event) => {
+                          event.stopPropagation();
+                          scrollZoomToIndex(idx);
+                        }}
+                        className={`h-2 w-2 rounded-full border border-white/60 ${idx === zoomCurrentIndex ? 'bg-white' : 'bg-white/30'}`}
+                        aria-label={`Go to slide ${idx + 1}`}
+                      />
+                    ))}
+                  </div>
+                </div>
+              )}
             </div>
           </DialogPrimitive.Content>
         </DialogPortal>


### PR DESCRIPTION
### Motivation
- Make `CarouselZoom` visually consistent with `ImageZoom` by ensuring the zoom dialog renders above the overlay, uses the same close control styling, places navigation controls in the bottom area, and applies the same open/close transition effects.

### Description
- Add overlay transition and blur state classes to the dialog overlay (`transition-all data-[state=closed]:bg-transparent data-[state=closed]:backdrop-blur-0 data-[state=open]:bg-background/80 data-[state=open]:backdrop-blur-md motion-reduce:transition-none`).
- Apply reduced-motion safeguard to the dialog content (`motion-reduce:animate-none`) and ensure the content uses a raised stacking context with `z-[1001]` and the same zoom/fade animation classes used elsewhere.
- Update the close control to use `rounded-full bg-black/60 text-white` for parity with `ImageZoom`, and reposition carousel navigation into a bottom-aligned block with centered arrows above the preview dots while keeping the carousel initialization (`setApi`) and scroll behavior unchanged.
- Minor markup/formatting adjustments to the `Carousel` usage (prop and class formatting) with no behavioral changes to the carousel API integration.

### Testing
- Attempted to run the dev server with `npm run dev -- --port 3000`, but the environment failed with a MiniOxygen "Network connection lost" error, so visual verification could not be performed (failed).
- No automated screenshot or unit tests were captured or executed due to the environment/network failure (none succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696c7dccda58832f8d16790cc38c9dfa)