### PR TITLE
Fix mobile review video thumbnails

### DIFF
--- a/app/components/global/ProductReviewsDisplay.tsx
+++ b/app/components/global/ProductReviewsDisplay.tsx
@@ -76,6 +76,7 @@ const ProductReviewsDisplay = ({
     {
       url: customerVideo,
       type: 'video',
+      posterUrl: customerImage ?? undefined,
     },
     {
       url: customerImage,
@@ -425,8 +426,8 @@ const ProductReviewsDisplay = ({
                             className="home-video__player"
                             controls
                             playsInline
-                            
-                            poster={customerVideo}
+                            preload="metadata"
+                            poster={customerImage ?? undefined}
                           >
                             <source src={customerVideo} type="video/mp4" />
                           </video>

--- a/app/components/global/ReviewMediaCarousel.tsx
+++ b/app/components/global/ReviewMediaCarousel.tsx
@@ -14,6 +14,7 @@ import '../../styles/routeStyles/product.css';
 interface ReviewMedia {
   url: string;
   type: string;
+  posterUrl?: string;
 }
 
 export const ReviewMediaCarousel = ({
@@ -97,8 +98,8 @@ export const ReviewMediaCarousel = ({
                           className="home-video__player"
                           controls
                           playsInline
-                          preload='auto'
-                          poster={img.url}
+                          preload="metadata"
+                          poster={img.posterUrl}
                         >
                           <source src={img.url} type="video/mp4" />
                         </video>


### PR DESCRIPTION
### Motivation
- Mobile devices showed a black rectangle instead of a video thumbnail because the video `poster` was being set improperly and `preload` was `auto`; use the review image as a proper poster and reduce preload to metadata to improve thumbnail display.

### Description
- Add an optional `posterUrl` to the `ReviewMedia` shape, use `poster={img.posterUrl}` in `ReviewMediaCarousel.tsx`, set `poster={customerImage}` for standalone videos in `ProductReviewsDisplay.tsx`, and change `preload` to `"metadata"` for both video elements.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eaf92a728832fa874be3ae898ad3c)