### PR TITLE
Fix review video poster capture on mobile

### DIFF
--- a/app/components/global/ReviewVideoPlayer.tsx
+++ b/app/components/global/ReviewVideoPlayer.tsx
@@ -14,7 +14,9 @@ const ReviewVideoPlayer = ({src, className}: ReviewVideoPlayerProps) => {
     const video = videoRef.current;
     if (!video || !src) return;
 
-    const handleLoadedData = () => {
+    let didCapture = false;
+    const captureFrame = () => {
+      if (didCapture || !video.videoWidth || !video.videoHeight) return;
       const canvas = document.createElement('canvas');
       canvas.width = video.videoWidth;
       canvas.height = video.videoHeight;
@@ -23,14 +25,38 @@ const ReviewVideoPlayer = ({src, className}: ReviewVideoPlayerProps) => {
       context.drawImage(video, 0, 0, canvas.width, canvas.height);
       try {
         setPoster(canvas.toDataURL('image/jpeg'));
+        didCapture = true;
       } catch (error) {
         setPoster(undefined);
       }
     };
 
+    const handleLoadedData = () => {
+      captureFrame();
+    };
+
+    const handleLoadedMetadata = () => {
+      if (Number.isFinite(video.duration) && video.duration > 0) {
+        const targetTime = Math.min(0.1, video.duration / 2);
+        try {
+          video.currentTime = targetTime;
+        } catch (error) {
+          captureFrame();
+        }
+      }
+    };
+
+    const handleSeeked = () => {
+      captureFrame();
+    };
+
     video.addEventListener('loadeddata', handleLoadedData);
+    video.addEventListener('loadedmetadata', handleLoadedMetadata);
+    video.addEventListener('seeked', handleSeeked);
     return () => {
       video.removeEventListener('loadeddata', handleLoadedData);
+      video.removeEventListener('loadedmetadata', handleLoadedMetadata);
+      video.removeEventListener('seeked', handleSeeked);
     };
   }, [src]);
 
@@ -42,7 +68,7 @@ const ReviewVideoPlayer = ({src, className}: ReviewVideoPlayerProps) => {
       className={className}
       controls
       playsInline
-      preload="auto"
+      preload="metadata"
       crossOrigin="anonymous"
       poster={poster}
     >


### PR DESCRIPTION
### Motivation
- Mobile browsers often do not provide a usable video frame at `loadeddata`, resulting in a black thumbnail before play.  
- The component needs to reliably generate a poster image from the video so review thumbnails are visible on mobile.  

### Description
- Added a `captureFrame` helper and `didCapture` flag to capture a single poster frame and avoid repeated captures.  
- Added `loadedmetadata` handler that seeks the video to a small target time and added a `seeked` handler to capture the frame after seeking.  
- Switched video attribute from `preload="auto"` to `preload="metadata"` to support the metadata/seek-based capture flow and wired up proper event cleanup.  

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696eb3c41d64832f997a1c081e0ff320)