### PR TITLE
Replace <video> with <iframe> in ReviewVideoPlayer

### DIFF
--- a/app/components/global/ReviewVideoPlayer.tsx
+++ b/app/components/global/ReviewVideoPlayer.tsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef, useState} from 'react';
+import React from 'react';
 
 interface ReviewVideoPlayerProps {
   src?: string;
@@ -6,74 +6,16 @@ interface ReviewVideoPlayerProps {
 }
 
 const ReviewVideoPlayer = ({src, className}: ReviewVideoPlayerProps) => {
-  const videoRef = useRef<HTMLVideoElement | null>(null);
-  const [poster, setPoster] = useState<string | undefined>();
-
-  useEffect(() => {
-    setPoster(undefined);
-    const video = videoRef.current;
-    if (!video || !src) return;
-
-    let didCapture = false;
-    const captureFrame = () => {
-      if (didCapture || !video.videoWidth || !video.videoHeight) return;
-      const canvas = document.createElement('canvas');
-      canvas.width = video.videoWidth;
-      canvas.height = video.videoHeight;
-      const context = canvas.getContext('2d');
-      if (!context) return;
-      context.drawImage(video, 0, 0, canvas.width, canvas.height);
-      try {
-        setPoster(canvas.toDataURL('image/jpeg'));
-        didCapture = true;
-      } catch (error) {
-        setPoster(undefined);
-      }
-    };
-
-    const handleLoadedData = () => {
-      captureFrame();
-    };
-
-    const handleLoadedMetadata = () => {
-      if (Number.isFinite(video.duration) && video.duration > 0) {
-        const targetTime = Math.min(0.1, video.duration / 2);
-        try {
-          video.currentTime = targetTime;
-        } catch (error) {
-          captureFrame();
-        }
-      }
-    };
-
-    const handleSeeked = () => {
-      captureFrame();
-    };
-
-    video.addEventListener('loadeddata', handleLoadedData);
-    video.addEventListener('loadedmetadata', handleLoadedMetadata);
-    video.addEventListener('seeked', handleSeeked);
-    return () => {
-      video.removeEventListener('loadeddata', handleLoadedData);
-      video.removeEventListener('loadedmetadata', handleLoadedMetadata);
-      video.removeEventListener('seeked', handleSeeked);
-    };
-  }, [src]);
-
   if (!src) return null;
 
   return (
-    <video
-      ref={videoRef}
+    <iframe
       className={className}
-      controls
-      playsInline
-      preload="metadata"
-      crossOrigin="anonymous"
-      poster={poster}
-    >
-      <source src={src} type="video/mp4" />
-    </video>
+      src={src}
+      title="Review video player"
+      allow="autoplay; fullscreen; picture-in-picture"
+      allowFullScreen
+    />
   );
 };
 


### PR DESCRIPTION
### Motivation
- The review player previously implemented an HTML `<video>` element with runtime poster capture logic which is no longer needed for the intended embedding behavior.
- Switching to an `<iframe>` allows embedding an external player/source URL directly and simplifies playback responsibilities.

### Description
- Removed the `useRef`, `useState`, and `useEffect` logic that captured a poster frame from the video and simplified the component import to `React` only.
- Replaced the `<video>` element and its `<source>` with an `<iframe>` that uses the provided `src` and includes `allow="autoplay; fullscreen; picture-in-picture"` and `allowFullScreen` attributes.
- Preserved the component API by keeping the `ReviewVideoPlayerProps` (`src` and `className`) and returning `null` when `src` is not provided.
- The change is contained in `app/components/global/ReviewVideoPlayer.tsx` where ~65 lines of video handling were removed and ~7 lines of iframe markup were added.

### Testing
- No automated tests were run for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697187a769e4832fb7cf3f161354c0e9)