### PR TITLE
Match sitewide ratings display to product ratings style

### DIFF
--- a/app/components/products/featuredProductReviews.tsx
+++ b/app/components/products/featuredProductReviews.tsx
@@ -3,6 +3,7 @@ import {Suspense} from 'react';
 import ProductReviewsCarousel from '../global/ProductReviewsCarousel';
 import {Separator} from '../ui/separator';
 import type {Review} from '../global/ProductReviewsDisplay';
+import {Rating, RatingButton} from '../ui/shadcn-io/rating';
 
 interface FeaturedReviewsQuery {
   products: {
@@ -63,6 +64,9 @@ function FeaturedProductReviews({
               const averageRating = totalRatings
                 ? totalStars / totalRatings
                 : 0;
+              const formattedAverageRating = totalRatings
+                ? averageRating.toFixed(2)
+                : '0.0';
 
               if (!featuredReviews.length) return null;
               //   let parsedReviews: any[] = [];
@@ -134,13 +138,48 @@ function FeaturedProductReviews({
               return (
                 <>
                   <div className="flex flex-col items-center gap-1 pb-4 text-center">
-                    <p className="text-sm text-muted-foreground">
-                      {totalRatings.toLocaleString()} total rating
-                      {totalRatings === 1 ? '' : 's'} site-wide
-                    </p>
-                    <p className="text-lg font-semibold">
-                      Average rating: {averageRating.toFixed(2)} / 5
-                    </p>
+                    <div className="average-product-rating">
+                      <div className="flex items-center gap-2">
+                        <div
+                          className="relative flex items-center"
+                          aria-hidden="true"
+                        >
+                          <Rating
+                            readOnly
+                            value={5}
+                            className="text-muted-foreground"
+                            aria-label="Maximum rating of 5 stars"
+                          >
+                            {Array.from({length: 5}).map((_, index) => (
+                              <RatingButton key={index} className="h-5 w-5 p-0.5" />
+                            ))}
+                          </Rating>
+                          <div
+                            className="absolute inset-0 overflow-hidden text-yellow-400"
+                            style={{
+                              width: `${(averageRating / 5) * 100 + 2}%`,
+                            }}
+                          >
+                            <Rating readOnly value={5} className="text-yellow-400">
+                              {Array.from({length: 5}).map((_, index) => (
+                                <RatingButton
+                                  key={index}
+                                  className="h-5 w-5 p-0.5"
+                                  aria-label={`Average rating ${formattedAverageRating} out of 5`}
+                                />
+                              ))}
+                            </Rating>
+                          </div>
+                        </div>
+                        <span className="text-sm text-muted-foreground">
+                          {formattedAverageRating} (
+                          {totalRatings === 1
+                            ? '1 review'
+                            : `${totalRatings.toLocaleString()} reviews`}
+                          )
+                        </span>
+                      </div>
+                    </div>
                   </div>
                   <ProductReviewsCarousel
                     reviews={featuredReviews}


### PR DESCRIPTION
### Motivation
- Display the site-wide average rating the same way individual product pages show it, using star-fill visualization, the numeric average, and the total review count in parentheses.

### Description
- Updated `app/components/products/featuredProductReviews.tsx` to import `Rating` and `RatingButton` from `../ui/shadcn-io/rating` and compute a `formattedAverageRating` value.
- Replaced the prior plain-text site-wide rating block with the `average-product-rating` markup used on product pages, rendering the star background, yellow-filled overlay based on `averageRating`, the formatted average, and the review count.
- Kept existing review carousel and feature filtering logic unchanged.

### Testing
- Committed the change (`git commit`) successfully and staged the modified file `app/components/products/featuredProductReviews.tsx`.
- Attempted to start the dev server with `npm run dev`, which printed a local URL but reported dependency resolution warnings for `@supabase/gotrue-js` and MiniOxygen/runtime errors during startup.
- Tried to capture a screenshot with Playwright which failed to load the page with `ERR_EMPTY_RESPONSE`, so no browser-based verification completed and no automated unit tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6971bb4f66b0832f939ec87b44f9b33d)