### PR TITLE
Add account menu dropdown arrow toggle

### DIFF
--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -24,7 +24,7 @@ import {LuAlignLeft, LuSearch, LuShoppingCart, LuUser} from 'react-icons/lu';
 import '../components/navbar/styles/Navbar.css';
 import {HoverCard, HoverCardContent, HoverCardTrigger} from './ui/hover-card';
 import {useIsLoggedIn} from '~/lib/hooks';
-import {Divide} from 'lucide-react';
+import {ChevronUp, Divide} from 'lucide-react';
 import {log} from 'util';
 
 interface HeaderProps {
@@ -890,6 +890,7 @@ function HeaderCtas({
     icon: string;
   };
   const loginValue = useIsLoggedIn(isLoggedIn);
+  const [accountMenuOpen, setAccountMenuOpen] = useState(false);
 
   const links: NavLink[] = [
     {href: '/', label: 'Home', icon: 'home-icon'},
@@ -904,17 +905,40 @@ function HeaderCtas({
     <nav className="header-ctas" role="navigation">
       {/* <HeaderMenuMobileToggle /> */}
 
-      <RadixHoverCard.Root openDelay={100} closeDelay={100}>
+      <RadixHoverCard.Root
+        open={accountMenuOpen}
+        onOpenChange={setAccountMenuOpen}
+        openDelay={100}
+        closeDelay={100}
+      >
         <RadixHoverCard.Trigger asChild>
           <NavLink prefetch="intent" to="/account">
             <div className="account-menu-dropdown">
               <Button
                 variant="outline"
-                className="flex gap-4 max-w-[100px] cursor-pointer"
+                className="flex items-center gap-2 max-w-[100px] cursor-pointer"
               >
                 {/* <LuAlignLeft className="w-6 h-6" /> */}
                 {/* Place dropdown arrow here */}
                 <LuUser className="w-6 h-6 bg-primary rounded-full text-white" />
+                <button
+                  type="button"
+                  aria-label="Toggle account menu"
+                  aria-expanded={accountMenuOpen}
+                  className="ps-[1px] text-primary cursor-default"
+                  onClick={(event) => {
+                    event.preventDefault();
+                    event.stopPropagation();
+                    setAccountMenuOpen((currentOpen) => !currentOpen);
+                  }}
+                >
+                  <ChevronUp
+                    className={`rounded-md border border-input transition-transform duration-200 ${
+                      accountMenuOpen ? 'rotate-180' : 'rotate-0'
+                    }`}
+                    size={18}
+                  />
+                </button>
                 {/* <Suspense fallback="Sign in">
                 <Await resolve={isLoggedIn} errorElement="Sign in">
                   {(isLoggedIn) => (isLoggedIn ? 'Account' : 'Sign in')}


### PR DESCRIPTION
### Motivation
- Provide the account menu the same dropdown-arrow behavior as `AboutDropdown` and `ServicesDropdown`, allowing the menu to open on hover or when the arrow is clicked while keeping the rest of the account button navigable.
- Prevent navigation when clicking the arrow so the arrow only toggles the dropdown instead of redirecting to the account page.

### Description
- Import `ChevronUp` and add local `accountMenuOpen` state to control the account hover-card open state.
- Make `RadixHoverCard.Root` controlled via `open={accountMenuOpen}` and `onOpenChange={setAccountMenuOpen}` to sync hover and click interactions.
- Add a chevron `button` next to the `LuUser` icon inside the account trigger that calls `event.preventDefault()` and `event.stopPropagation()` then toggles `accountMenuOpen`, and flip the chevron using a conditional `rotate-180` class when open.
- Adjust trigger layout to `flex items-center gap-2` and add appropriate `aria-` attributes so the arrow behaves like the other dropdown arrows.

### Testing
- Ran `npm run dev -- --host --port 4173` to start the dev server, but the first invocation reported an unexpected argument error and was re-invoked correctly.
- After re-invocation the dev server started, but `MiniOxygen` fetch/network errors occurred during startup which prevented completing interactive UI verification of the new toggle.
- No automated unit or integration tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6973febfa760832f9b848afdb1111abb)