### PR TITLE
Fix In the Box carousel card sizing and spacing

### DIFF
--- a/app/components/global/ThreeUpCarouselBox.tsx
+++ b/app/components/global/ThreeUpCarouselBox.tsx
@@ -31,9 +31,12 @@ export default function ThreeUpCarouselBox({cards}: ThreeUpCarouselBoxProps) {
     return () => window.removeEventListener('resize', handleResize);
   }, []);
 
+  const carouselGapRem = 1;
+
   function slideStyleForCount(count: number) {
-    const percent = 100 / count;
-    return {flex: `0 0 ${percent}%`, maxWidth: `${percent}%`};
+    const gapTotalRem = (count - 1) * carouselGapRem;
+    const width = `calc((100% - ${gapTotalRem}rem) / ${count})`;
+    return {flex: `0 0 ${width}`, maxWidth: width};
   }
 
   // Determine slides per view + alignment logic
@@ -58,7 +61,7 @@ export default function ThreeUpCarouselBox({cards}: ThreeUpCarouselBoxProps) {
           slidesToScroll: 1,
         }}
       >
-        <CarouselContent className="!flex !items-stretch !justify-start">
+        <CarouselContent className="!flex !items-stretch !justify-start gap-4">
           {/* ≥ 1024px (3 slides) */}
           {windowWidth && windowWidth >= 1024 && (
             <>
@@ -66,7 +69,7 @@ export default function ThreeUpCarouselBox({cards}: ThreeUpCarouselBoxProps) {
                 <CarouselItem
                   key={idx}
                   style={slideStyleForCount(3)}
-                  className="flex justify-center mx-2"
+                  className="flex justify-center"
                 >
                   <Card className="w-full">
                     <CardHeader>
@@ -110,7 +113,7 @@ export default function ThreeUpCarouselBox({cards}: ThreeUpCarouselBoxProps) {
                   style={slideStyleForCount(2)}
                   className="flex justify-center items-stretch"
                 >
-                  <Card className="group w-full max-w-[420px] mx-2 p-4 overflow-visible">
+                  <Card className="group w-full max-w-[420px] p-4 overflow-visible">
                     <CardHeader>
                       <div className="flex justify-start">
                         <img


### PR DESCRIPTION
### Motivation
- On large viewports (≥1024px) the three visible cards were slightly cropped and overlapped due to per-item margins and not accounting for the inter-slide gap when sizing slides. 
- The carousel should show exactly three fully-visible cards with the next card fully introduced when navigating, with no overlap or clipping.

### Description
- Add `carouselGapRem = 1` and update `slideStyleForCount` to compute each slide width as `calc((100% - ${gapTotal}rem) / ${count})` so slide sizing accounts for the total gap space. 
- Apply a consistent gap by adding `gap-4` to the `CarouselContent` container so spacing is driven by the container gap instead of per-item margins. 
- Remove per-item horizontal margins (`mx-2`) from the three-up layout and from the card wrapper so slides align precisely with the computed widths. 
- Changes are contained in `app/components/global/ThreeUpCarouselBox.tsx` and preserve the existing slides-per-view breakpoints and alignment logic.

### Testing
- Attempted to run the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, but the process failed immediately with `Unexpected argument: 0.0.0.0`, so interactive/manual verification was not completed. 
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69746d682644832f843ab9af2d1ea658)