### PR TITLE
Adjust inthebox carousel nav spacing on small screens

### DIFF
--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -843,6 +843,14 @@ span {
     width: 88vw;
   }
 }
+@media (max-width: 768px) {
+  .inthebox-carousel [data-slot='carousel-previous'] {
+    left: 0.75rem !important;
+  }
+  .inthebox-carousel [data-slot='carousel-next'] {
+    right: 0.75rem !important;
+  }
+}
 
 /* Make sure carousel content acts like a centered flex row */
 .you-may-like-carousel .carousel__content,


### PR DESCRIPTION
### Motivation

- Prevent the `inthebox-carousel` previous/next buttons from being cropped at the viewport edges on small screens by nudging them inward on viewports <= 768px.

### Description

- Add a mobile media query to `app/styles/app.css` that sets `[data-slot='carousel-previous'] { left: 0.75rem !important; }` and `[data-slot='carousel-next'] { right: 0.75rem !important; }` inside `@media (max-width: 768px)` to pull the arrows away from the edges, and no local skills were used.

### Testing

- Attempted to start the dev server with `npm run dev -- --host 0.0.0.0 --port 5173`, but `shopify hydrogen dev` rejected the host argument and the run failed, so no automated/UI tests were completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6974767a1914832fb754b0900173db6b)