### PR TITLE
Center review rating while preserving action placement

### DIFF
--- a/app/components/global/ProductReviewsDisplay.tsx
+++ b/app/components/global/ProductReviewsDisplay.tsx
@@ -349,7 +349,7 @@ const ProductReviewsDisplay = ({
                       </div>
                     </div>
                     
-                    <div>
+                    <div className="review-right-side-slot">
                       <div className="review-right-side-container">
                         <div className="ps-1 pt-2 pe-2 flex justify-end">
                           <div className="review-right-side">

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -1305,6 +1305,25 @@ span {
   align-items: center;
 }
 
+@media (min-width: 600px) {
+  .review-left-side-display .stars-writtenby-buttons {
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+  }
+
+  .review-left-side-display .stars-writtenby-buttons .rating-and-author {
+    grid-column: 2;
+    justify-self: center;
+  }
+
+  .review-left-side-display
+    .stars-writtenby-buttons
+    .review-right-side-slot {
+    grid-column: 3;
+    justify-self: end;
+  }
+}
+
 @media (max-width: 768px) {
   .faq-header-img {
     height: 75px;


### PR DESCRIPTION
### Motivation
- Ensure the rating and author block in the left review display is visually centered within the stars area on wider viewports (>= 600px) while keeping the action buttons (`Edit` / `Delete`) positioned as they currently appear on the right. 

### Description
- Add a dedicated wrapper `review-right-side-slot` in `app/components/global/ProductReviewsDisplay.tsx` around the review action buttons to provide a distinct layout target. 
- Add a media query in `app/styles/app.css` that changes `.stars-writtenby-buttons` to a three-column grid (`1fr auto 1fr`) at `@media (min-width: 600px)` to center `.rating-and-author` in the middle column. 
- In the same media query place `.rating-and-author` into the center grid column and move `.review-right-side-slot` into the right column with `justify-self: end`, leaving behavior for viewports < 600px unchanged. 

### Testing
- Attempted to launch the dev server with `npm run dev`, which started but reported dependency resolution warnings and MiniOxygen fetch errors, preventing reliable end-to-end rendering verification. 
- Attempted to capture a screenshot via Playwright against `http://127.0.0.1:4173/`, but navigation failed with `ERR_EMPTY_RESPONSE`, so visual tests could not complete. 
- No automated unit tests were added or run because this is a UI/CSS layout change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69755ecacc00832f85fcdaa13b5f62a9)