### PR TITLE
Add video replacement controls to review editor

### DIFF
--- a/app/components/global/AccountReviews.tsx
+++ b/app/components/global/AccountReviews.tsx
@@ -172,6 +172,7 @@ const AccountReviews = ({
       title: string;
       stars: number;
       image?: File | null;
+      video?: File | null;
       isFeatured?: boolean;
     },
   ) => {
@@ -187,6 +188,9 @@ const AccountReviews = ({
     form.append('customerName', customerName ?? '');
     if (updates.image) {
       form.append('image', updates.image);
+    }
+    if (updates.video) {
+      form.append('video', updates.video);
     }
     if (typeof updates.isFeatured === 'boolean') {
       form.append('isFeatured', updates.isFeatured ? 'yes' : 'no');

--- a/app/components/global/ProductReviewsDisplay.tsx
+++ b/app/components/global/ProductReviewsDisplay.tsx
@@ -39,6 +39,7 @@ interface ProductReviewsDisplayProps {
       title: string;
       stars: number;
       image?: File | null;
+      video?: File | null;
       isFeatured?: boolean;
     },
   ) => Promise<void> | void;
@@ -57,6 +58,8 @@ const ProductReviewsDisplay = ({
 
   const [selectedImage, setSelectedImage] = useState<File | null>(null);
   const [imagePreview, setImagePreview] = useState<string | null>(null);
+  const [selectedVideo, setSelectedVideo] = useState<File | null>(null);
+  const [videoPreview, setVideoPreview] = useState<string | null>(null);
 
   const routeData = useRouteLoaderData<{
     customer?: {customer?: {id?: string}};
@@ -128,12 +131,15 @@ const ProductReviewsDisplay = ({
     setEditStars(parsedStars);
     setSelectedImage(null);
     setImagePreview(customerImage ?? null);
+    setSelectedVideo(null);
+    setVideoPreview(customerVideo ?? null);
     setEditIsFeatured(review.isFeatured ?? false);
   }, [
     displayTitle,
     displayText,
     parsedStars,
     customerImage,
+    customerVideo,
     review.isFeatured,
   ]);
 
@@ -143,13 +149,21 @@ const ProductReviewsDisplay = ({
     setEditStars(parsedStars);
     setSelectedImage(null);
     setImagePreview(customerImage ?? null);
+    setSelectedVideo(null);
+    setVideoPreview(customerVideo ?? null);
     setEditIsFeatured(review.isFeatured ?? false);
   };
 
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImageFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0] ?? null;
     setSelectedImage(file);
     setImagePreview(file ? URL.createObjectURL(file) : (customerImage ?? null));
+  };
+
+  const handleVideoFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0] ?? null;
+    setSelectedVideo(file);
+    setVideoPreview(file ? URL.createObjectURL(file) : (customerVideo ?? null));
   };
 
   const handleRemove = async () => {
@@ -173,6 +187,7 @@ const ProductReviewsDisplay = ({
         title: editTitle,
         stars: editStars,
         image: selectedImage,
+        video: selectedVideo,
         isFeatured: isAdmin ? editIsFeatured : undefined,
       });
       setIsEditing(false);
@@ -275,7 +290,7 @@ const ProductReviewsDisplay = ({
                 accept="image/*"
                 className="hidden"
                 id={`edit-image-${review.createdAt}`}
-                onChange={handleFileChange}
+                onChange={handleImageFileChange}
               />
               <div className="flex justify-center">
                 <Button
@@ -290,6 +305,39 @@ const ProductReviewsDisplay = ({
                   disabled={isSaving}
                 >
                   Upload New Image
+                </Button>
+              </div>
+
+              {videoPreview && (
+                <div className="home-video px-2 pb-2">
+                  <ReviewVideoPlayer
+                    className="home-video__player"
+                    src={videoPreview}
+                  />
+                </div>
+              )}
+
+              {/* Video upload */}
+              <input
+                type="file"
+                accept="video/*"
+                className="hidden"
+                id={`edit-video-${review.createdAt}`}
+                onChange={handleVideoFileChange}
+              />
+              <div className="flex justify-center">
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() =>
+                    document
+                      .getElementById(`edit-video-${review.createdAt}`)
+                      ?.click()
+                  }
+                  className="cursor-pointer mb-4"
+                  disabled={isSaving}
+                >
+                  Upload New Video
                 </Button>
               </div>
               <div className="title-body-character-limit mx-5">

--- a/app/routes/products.$handle.tsx
+++ b/app/routes/products.$handle.tsx
@@ -747,6 +747,7 @@ export default function Product() {
       title: string;
       stars: number;
       image?: File | null;
+      video?: File | null;
       isFeatured?: boolean;
     },
   ) => {
@@ -762,6 +763,9 @@ export default function Product() {
     form.append('customerName', customerName);
     if (updates.image) {
       form.append('image', updates.image);
+    }
+    if (updates.video) {
+      form.append('video', updates.video);
     }
     if (isAdmin && typeof updates.isFeatured === 'boolean') {
       form.append('isFeatured', updates.isFeatured ? 'yes' : 'no');


### PR DESCRIPTION
### Motivation
- Allow authors and admins to replace the review video when editing a review in addition to the existing image replacement flow. 
- Ensure previews show both image and video when present, and display the existing single-media type when only one is present. 
- Match video preview styling to existing review display styling so the editor shows a faithful preview of the published review media. 

### Description
- Added video state, preview and change handlers to the editor in `app/components/global/ProductReviewsDisplay.tsx` via `selectedVideo`, `videoPreview`, `handleVideoFileChange`, a hidden `input` for `accept="video/*"`, and an `Upload New Video` button. 
- Render the `videoPreview` with `ReviewVideoPlayer` using the same classes used elsewhere (`home-video` / `home-video__player`) and keep the existing image preview and `Upload New Image` flow unchanged. 
- Thread the selected video through the edit flow by passing `video: selectedVideo` into the `onEdit` payload in `ProductReviewsDisplay`. 
- Include optional `video` fields in review-edit form submissions by adding `video?: File | null` to the update types and appending `form.append('video', updates.video)` in `app/components/global/AccountReviews.tsx` and `app/routes/products.$handle.tsx`. 

### Testing
- No automated tests were executed as part of this change. 
- Changes were type-checked by inspection and committed; runtime verification was not performed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69757e4d0aa0832f8e9f9f04710d9246)