### PR TITLE
Show product link only on featured reviews and refresh edit video preview

### DIFF
--- a/app/components/global/ProductReviewsCarousel.tsx
+++ b/app/components/global/ProductReviewsCarousel.tsx
@@ -6,6 +6,7 @@ interface ProductReviewsCarouselProps {
   reviews: Review[];
   isAdmin: Boolean;
   currentCustomerId?: string;
+  showProductLink?: boolean;
   onRemove?: (review: Review) => Promise<void> | void;
   onEdit?: (
     review: Review,
@@ -25,6 +26,7 @@ export default function ProductReviewsCarousel({
   currentCustomerId,
   onRemove,
   onEdit,
+  showProductLink = false,
 }: ProductReviewsCarouselProps) {
   const contentRef = useRef<HTMLDivElement | null>(null);
   const [contentHeight, setContentHeight] = useState(0);
@@ -85,6 +87,7 @@ export default function ProductReviewsCarousel({
                   onRemove={onRemove}
                   onEdit={onEdit}
                   isAdmin={isAdmin}
+                  showProductLink={showProductLink}
                 />
               </div>
             ))}

--- a/app/components/global/ProductReviewsDisplay.tsx
+++ b/app/components/global/ProductReviewsDisplay.tsx
@@ -31,6 +31,7 @@ interface ProductReviewsDisplayProps {
   review: Review;
   isAdmin: Boolean;
   currentCustomerId?: string;
+  showProductLink?: boolean;
   onRemove?: (review: Review) => Promise<void> | void;
   onEdit?: (
     review: Review,
@@ -51,6 +52,7 @@ const ProductReviewsDisplay = ({
   onRemove,
   onEdit,
   isAdmin,
+  showProductLink = false,
 }: ProductReviewsDisplayProps) => {
   const [isRemoving, setIsRemoving] = useState(false);
   const [isEditing, setIsEditing] = useState(false);
@@ -311,6 +313,7 @@ const ProductReviewsDisplay = ({
               {videoPreview && (
                 <div className="home-video px-2 pb-2">
                   <ReviewVideoPlayer
+                    key={videoPreview}
                     className="home-video__player"
                     src={videoPreview}
                   />
@@ -451,17 +454,16 @@ const ProductReviewsDisplay = ({
                   </div>
                 </>
               )}
-              <div className="w-full flex justify-center">
-
-              <Link
-                    to={`/products/${replaceSpacesWithDashes(productName)}`}
-                    
-                  >
-
-                  {/* <button className='cursor-pointer hover:text-primary hover:underline text-muted-foreground pb-2'>{productName}</button> */}
-                  <button className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80 hover:text-primary py-1 px-2 mb-2 mt-1">{productName}</button>
+              {showProductLink && productName && (
+                <div className="w-full flex justify-center">
+                  <Link to={`/products/${replaceSpacesWithDashes(productName)}`}>
+                    {/* <button className='cursor-pointer hover:text-primary hover:underline text-muted-foreground pb-2'>{productName}</button> */}
+                    <button className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80 hover:text-primary py-1 px-2 mb-2 mt-1">
+                      {productName}
+                    </button>
                   </Link>
-              </div>
+                </div>
+              )}
                 <div className="customer-media-container">
                 {customerImage && customerVideo ? (
                   <CarouselZoom items={urls}>

--- a/app/components/products/featuredProductReviews.tsx
+++ b/app/components/products/featuredProductReviews.tsx
@@ -128,6 +128,7 @@ function FeaturedProductReviews({
                       'gid://shopify/Customer/7968375079049'
                     }
                     currentCustomerId={currentCustomerId}
+                    showProductLink
                     //   onEdit={}
                   />
                 </>


### PR DESCRIPTION
### Motivation
- Prevent the product link button from rendering on individual product review cards where it was either empty or irrelevant. 
- Ensure the review edit UI updates the displayed video preview immediately when a user selects a replacement video.

### Description
- Added a `showProductLink?: boolean` prop to `ProductReviewsDisplay` and `ProductReviewsCarousel` and defaulted it to `false` so product link rendering is opt-in. 
- Propagated `showProductLink` from `FeaturedProductReviews` into the carousel so the product link only appears for featured reviews by passing `showProductLink`. 
- Conditionally render the product link button only when `showProductLink` is `true` and `productName` is present. 
- Force the edit-mode `ReviewVideoPlayer` to remount when a new preview URL is selected by adding `key={videoPreview}` so the selected replacement video displays immediately.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69758ca2fa58832fa7b19c50ffde62ca)