### PR TITLE
Add keyboard navigation (Escape & Arrow keys) to CarouselZoom

### DIFF
--- a/components/ui/shadcn-io/carousel-zoom/index.tsx
+++ b/components/ui/shadcn-io/carousel-zoom/index.tsx
@@ -36,6 +36,7 @@ export const CarouselZoom = ({items, children}: CarouselZoomProps) => {
   );
   const [zoomCurrentIndex, setZoomCurrentIndex] = React.useState(0);
   const [zoomTotalItems, setZoomTotalItems] = React.useState(0);
+  const scrollZoomToIndex = (index: number) => zoomCarouselApi?.scrollTo(index);
 
   React.useEffect(() => {
     if (!zoomCarouselApi) return;
@@ -56,12 +57,37 @@ export const CarouselZoom = ({items, children}: CarouselZoomProps) => {
     zoomCarouselApi.scrollTo(zoomIndex, true);
   }, [zoomCarouselApi, isOpen, zoomIndex]);
 
+  React.useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        setIsOpen(false);
+        return;
+      }
+
+      if (!zoomCarouselApi || zoomTotalItems <= 1) return;
+
+      if (event.key === 'ArrowLeft') {
+        event.preventDefault();
+        scrollZoomToIndex(zoomCurrentIndex - 1);
+      }
+
+      if (event.key === 'ArrowRight') {
+        event.preventDefault();
+        scrollZoomToIndex(zoomCurrentIndex + 1);
+      }
+    };
+
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, scrollZoomToIndex, zoomCarouselApi, zoomCurrentIndex, zoomTotalItems]);
+
   const openAtIndex = (index: number) => {
     setZoomIndex(index);
     setIsOpen(true);
   };
-
-  const scrollZoomToIndex = (index: number) => zoomCarouselApi?.scrollTo(index);
 
   return (
     <>


### PR DESCRIPTION
### Motivation
- Improve accessibility and UX by allowing keyboard control of the zoom dialog so `Escape` closes it and `ArrowLeft`/`ArrowRight` navigate slides while the dialog is open.

### Description
- Modify `components/ui/shadcn-io/carousel-zoom/index.tsx` to register a `keydown` handler when the dialog is open that closes on `Escape` and calls `scrollZoomToIndex` for `ArrowLeft`/`ArrowRight`, and move the `scrollZoomToIndex` helper above the effect so it can be used there.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69769fe82d1c832f9fcf8814bba4748a)