### PR TITLE
Fix aside dismissal on outside click

### DIFF
--- a/app/components/Aside.tsx
+++ b/app/components/Aside.tsx
@@ -4,6 +4,7 @@ import {
   type ReactNode,
   useContext,
   useEffect,
+  useRef,
   useState,
 } from 'react';
 
@@ -46,6 +47,7 @@ export function Aside({
   const location = useLocation();
   const imageSource = determineActiveTypeImage();
   const [windowWidth, setWindowWidth] = useState<number | undefined>(undefined);
+  const asideRef = useRef<HTMLElement | null>(null);
 
   useEffect(() => {
     function handleResize() {
@@ -61,6 +63,20 @@ export function Aside({
       close();
     }
     if (expanded) {
+      document.addEventListener(
+        'pointerdown',
+        (event) => {
+          const target = event.target;
+          if (!(target instanceof Node)) {
+            return;
+          }
+          if (asideRef.current?.contains(target)) {
+            return;
+          }
+          close();
+        },
+        {signal: abortController.signal},
+      );
       document.addEventListener(
         'keydown',
         function handler(event: KeyboardEvent) {
@@ -82,7 +98,7 @@ export function Aside({
     >
       <button className="close-outside" onClick={close} />
 
-      <aside className="border-l">
+      <aside className="border-l" ref={asideRef}>
         {windowWidth != null && windowWidth > 1023 && (
           <div className="mt-[70px]">
             <div className="flex justify-end pe-4">


### PR DESCRIPTION
### Motivation
- Clicking outside the Aside previously did not close it while `Escape` worked, so the Aside should dismiss on outside clicks but remain open for clicks inside.

### Description
- Add `asideRef` via `useRef<HTMLElement | null>` and attach it to the `aside` element to detect inside vs outside clicks.
- Register a `pointerdown` listener on `document` while the aside is expanded that inspects `event.target` and calls `close()` when the target is not contained within the `aside`.
- Use an `AbortController` to attach listeners with a `signal` so the `pointerdown` and existing `keydown` (`Escape`) handlers are removed when the aside closes or the component unmounts.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976b64094a8832f81dc860e6d6d5681)