### PR TITLE
Add toast notifications for cart and review actions

### DIFF
--- a/app/components/AddToCartButton.tsx
+++ b/app/components/AddToCartButton.tsx
@@ -1,8 +1,7 @@
 import {type FetcherWithComponents} from '@remix-run/react';
 import {CartForm, type OptimisticCartLineInput} from '@shopify/hydrogen';
-import {Button} from './ui/button';
-import {useEffect, useState} from 'react';
-import {layout} from '@remix-run/route-config';
+import {useEffect, useRef, useState} from 'react';
+import {toast} from 'sonner';
 
 export function AddToCartButton({
   analytics,
@@ -30,22 +29,60 @@ export function AddToCartButton({
     <CartForm route="/cart" inputs={{lines}} action={CartForm.ACTIONS.LinesAdd}>
       {(fetcher: FetcherWithComponents<any>) => (
         <>
-          <input
-            name="analytics"
-            type="hidden"
-            value={JSON.stringify(analytics)}
-          />
-
-          <button
-            type="submit"
+          <AddToCartContent
+            analytics={analytics}
+            disabled={disabled}
+            fetcher={fetcher}
             onClick={onClick}
-            disabled={disabled ?? fetcher.state !== 'idle'}
-            className="flex-1 cursor-pointer add-to-cart-btn inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-primary text-primary-foreground shadow hover:bg-primary/90"
           >
             {children}
-          </button>
+          </AddToCartContent>
         </>
       )}
     </CartForm>
+  );
+}
+
+function AddToCartContent({
+  analytics,
+  children,
+  disabled,
+  fetcher,
+  onClick,
+}: {
+  analytics?: unknown;
+  children: React.ReactNode;
+  disabled?: boolean;
+  fetcher: FetcherWithComponents<any>;
+  onClick?: () => void;
+}) {
+  const hasSubmitted = useRef(false);
+
+  useEffect(() => {
+    if (fetcher.state === 'submitting') {
+      hasSubmitted.current = true;
+    }
+
+    if (hasSubmitted.current && fetcher.state === 'idle') {
+      const hasErrors = Boolean(fetcher.data?.errors?.length);
+      if (!hasErrors) {
+        toast.success('Added to Cart');
+      }
+      hasSubmitted.current = false;
+    }
+  }, [fetcher.data, fetcher.state]);
+
+  return (
+    <>
+      <input name="analytics" type="hidden" value={JSON.stringify(analytics)} />
+      <button
+        type="submit"
+        onClick={onClick}
+        disabled={disabled ?? fetcher.state !== 'idle'}
+        className="flex-1 cursor-pointer add-to-cart-btn inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive bg-primary text-primary-foreground shadow hover:bg-primary/90"
+      >
+        {children}
+      </button>
+    </>
   );
 }

--- a/app/components/form/ReviewForm.tsx
+++ b/app/components/form/ReviewForm.tsx
@@ -5,6 +5,7 @@ import {Rating, RatingButton} from 'components/ui/shadcn-io/rating';
 import Sectiontitle from '../global/Sectiontitle';
 import {ReloadIcon} from '@radix-ui/react-icons';
 import {Link} from '@remix-run/react';
+import {toast} from 'sonner';
 
 const REVIEW_CHAR_LIMIT = 200;
 
@@ -117,6 +118,12 @@ function ReviewForm({
         headers: {Accept: 'application/json'},
       });
 
+      if (!response.ok) {
+        console.error('Failed to add review', await response.text());
+        setPendingReviewSubmit(false);
+        return;
+      }
+
       const json = await response.json();
       updateExistingReviews(json.reviews);
 
@@ -129,6 +136,7 @@ function ReviewForm({
       setSelectedImage(null);
       setImagePreview(null);
       setReviewSubmittedMessage('Review Submitted!');
+      toast.success('Review Posted');
     } catch (err) {
       setPendingReviewSubmit(false);
       console.error(err);

--- a/app/components/global/AccountReviews.tsx
+++ b/app/components/global/AccountReviews.tsx
@@ -6,6 +6,7 @@ import ProductReviewsDisplay, {
   type Review,
 } from '~/components/global/ProductReviewsDisplay';
 import ProductCarousel from '../products/productCarousel';
+import {toast} from 'sonner';
 
 interface AccountReviewsProps {
   products: ProductReviewSource[];
@@ -160,6 +161,7 @@ const AccountReviews = ({
             : item,
         );
       });
+      toast.success('Review Deleted');
     } catch (error) {
       console.error('Error removing review', error);
     }
@@ -227,6 +229,7 @@ const AccountReviews = ({
             : item,
         );
       });
+      toast.success('Review Changes Saved');
     } catch (error) {
       console.error('Error editing review', error);
     }

--- a/app/components/products/featuredProductReviews.tsx
+++ b/app/components/products/featuredProductReviews.tsx
@@ -3,7 +3,8 @@ import {Suspense, useEffect, useMemo, useState} from 'react';
 import ProductReviewsCarousel from '../global/ProductReviewsCarousel';
 import {Separator} from '../ui/separator';
 import type {Review} from '../global/ProductReviewsDisplay';
-import { Rating, RatingButton } from 'components/ui/shadcn-io/rating';
+import {Rating, RatingButton} from 'components/ui/shadcn-io/rating';
+import {toast} from 'sonner';
 
 
 interface FeaturedReviewsQuery {
@@ -118,6 +119,7 @@ function FeaturedReviewsContent({
       setAllReviews((prev) =>
         mergeProductReviews(prev, review.productId ?? '', updatedReviews),
       );
+      toast.success('Review Deleted');
     } catch (error) {
       console.error('Error removing review', error);
     }
@@ -172,6 +174,7 @@ function FeaturedReviewsContent({
       setAllReviews((prev) =>
         mergeProductReviews(prev, review.productId ?? '', updatedReviews),
       );
+      toast.success('Review Changes Saved');
     } catch (error) {
       console.error('Error editing review', error);
     }

--- a/app/routes/products.$handle.tsx
+++ b/app/routes/products.$handle.tsx
@@ -732,6 +732,7 @@ export default function Product() {
       const data = await response.json();
       const updatedReviews = data?.reviews ?? [];
       setReviewsList(updatedReviews);
+      toast.success('Review Deleted');
     } catch (error) {
       console.error('Error removing review', error);
     }
@@ -786,6 +787,7 @@ export default function Product() {
       const data = await response.json();
       const updatedReviews = data?.reviews ?? [];
       setReviewsList(updatedReviews);
+      toast.success('Review Changes Saved');
     } catch (error) {
       console.error('Error editing review', error);
     }


### PR DESCRIPTION
### Motivation
- Provide immediate UI feedback when a product is added to cart and when reviews are created, edited, or deleted so users see confirmation messages for these common actions.
- Use the existing Sonner toaster to keep toast styling consistent across the app.
- Centralize the cart add success behavior so toasts run regardless of where a product is added from (product list or individual product page).

### Description
- Added an `AddToCartContent` wrapper to `app/components/AddToCartButton.tsx` that watches the `fetcher` lifecycle and shows `toast.success('Added to Cart')` after a successful `CartForm` submission.
- Added `toast.success('Review Posted')` and response error handling to the review creation flow in `app/components/form/ReviewForm.tsx` to avoid toasting on failed submissions.
- Added `toast.success('Review Deleted')` and `toast.success('Review Changes Saved')` to the review remove/edit handlers in `app/routes/products.$handle.tsx`, `app/components/products/featuredProductReviews.tsx`, and `app/components/global/AccountReviews.tsx` so deletions and edits show confirmation across product and account views.
- Imported `toast` from `sonner` where needed and preserved existing behavior/optimistic updates when updating review lists.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976bb1be198832f9cbe5b3079c53fce)