### PR TITLE
Match product rating star color with featured reviews

### DIFF
--- a/app/routes/products.$handle.tsx
+++ b/app/routes/products.$handle.tsx
@@ -1049,7 +1049,7 @@ const navigate = useNavigate();
                         className="absolute inset-0 overflow-hidden text-yellow-400"
                         style={{width: `${(averageRating / 5) * 100 + 2}%`}}
                       >
-                        <Rating readOnly value={5} className="text-yellow-400">
+                        <Rating readOnly value={5} className="stars">
                           {Array.from({length: 5}).map((_, index) => (
                             <RatingButton
                               key={index}
@@ -1179,11 +1179,7 @@ const navigate = useNavigate();
                             className="absolute inset-0 overflow-hidden text-yellow-400"
                             style={{width: `${(averageRating / 5) * 100 + 2}%`}}
                           >
-                            <Rating
-                              readOnly
-                              value={5}
-                              className="text-yellow-400"
-                            >
+                            <Rating readOnly value={5} className="stars">
                               {Array.from({length: 5}).map((_, index) => (
                                 <RatingButton
                                   key={index}
@@ -1815,7 +1811,7 @@ const navigate = useNavigate();
                         className="absolute inset-0 overflow-hidden text-yellow-400"
                         style={{width: `${(averageRating / 5) * 100 + 2}%`}}
                       >
-                        <Rating readOnly value={5} className="text-yellow-400">
+                        <Rating readOnly value={5} className="stars">
                           {Array.from({length: 5}).map((_, index) => (
                             <RatingButton
                               key={index}


### PR DESCRIPTION
### Motivation
- Ensure the star color used in the product page rating overlays (`products.$handle`) matches the shade used by the featured reviews component so ratings look consistent across the site.

### Description
- Replaced `className="text-yellow-400"` with the existing `className="stars"` on the overlaid `Rating` elements in `app/routes/products.$handle.tsx` so the overlay uses the `.stars` color definition.
- The change relies on the existing `.stars` rule in `app/styles/app.css` (`color: rgb(214, 183, 72);`) to standardize the yellow shade.
- Updated three rating overlay occurrences in `app/routes/products.$handle.tsx` to use `className="stars"`.

### Testing
- Launched the dev server with `npm run dev` which started the app and served at `http://localhost:3000/` but reported a missing dependency warning for `@supabase/gotrue-js` (partial success).
- Attempted a visual verification via Playwright to capture a screenshot, but Chromium crashed in this environment so the screenshot step failed.
- Changes were staged and committed successfully with `git commit`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976fb566700832f9ac9a1168cfb99da)