### PR TITLE
Play review videos in dialog with centered overlay and autoplay

### DIFF
--- a/app/components/global/ProductReviewsDisplay.tsx
+++ b/app/components/global/ProductReviewsDisplay.tsx
@@ -477,7 +477,7 @@ const ProductReviewsDisplay = ({
                     {(openAtIndex) => (
                       <ReviewMediaCarousel
                         url={urls}
-                        onImageClick={openAtIndex}
+                        onMediaClick={openAtIndex}
                       />
                     )}
                   </CarouselZoom>
@@ -495,14 +495,21 @@ const ProductReviewsDisplay = ({
                       </div>
                     )}
                     {customerVideo && (
-                      <>
-                        <div className="home-video px-2 pb-2">
-                          <ReviewVideoPlayer
-                            className="home-video__player"
-                            src={customerVideo}
-                          />
-                        </div>
-                      </>
+                      <CarouselZoom items={[{url: customerVideo, type: 'video'}]}>
+                        {(openAtIndex) => (
+                          <div className="home-video px-2 pb-2">
+                            <ReviewVideoPlayer
+                              className="home-video__player"
+                              src={customerVideo}
+                              showControls={false}
+                              showPlayOverlay
+                              onPlayClick={() =>
+                                openAtIndex(0, {autoplay: true})
+                              }
+                            />
+                          </div>
+                        )}
+                      </CarouselZoom>
                     )}
                   </>
                 )}

--- a/app/components/global/ReviewMediaCarousel.tsx
+++ b/app/components/global/ReviewMediaCarousel.tsx
@@ -7,7 +7,7 @@ import {
   CarouselItem,
 } from '../ui/carousel';
 import {Button} from '../ui/button';
-import {ChevronLeftIcon, ChevronRightIcon, XIcon} from 'lucide-react';
+import {ChevronLeftIcon, ChevronRightIcon} from 'lucide-react';
 import '../../styles/routeStyles/product.css';
 import ReviewVideoPlayer from './ReviewVideoPlayer';
 
@@ -20,11 +20,11 @@ interface ReviewMedia {
 
 export const ReviewMediaCarousel = ({
   url,
-  onImageClick,
+  onMediaClick,
 }: {
   // accept full product OR a looser shape (to silence type-checking when your caller doesn't have full objects)
   url: ReviewMedia[];
-  onImageClick?: (index: number) => void;
+  onMediaClick?: (index: number, options?: {autoplay?: boolean}) => void;
 }) => {
   const cardClassName =
     'group-hover:shadow-xl h-full transition-shadow duration-500 cursor-pointer';
@@ -85,7 +85,7 @@ export const ReviewMediaCarousel = ({
                       {img.type === 'image' && (
                         <button
                           type="button"
-                          onClick={() => onImageClick?.(idx)}
+                          onClick={() => onMediaClick?.(idx)}
                           className="cursor-zoom-in"
                         >
                           <img
@@ -98,6 +98,9 @@ export const ReviewMediaCarousel = ({
                         <ReviewVideoPlayer
                           className="home-video__player"
                           src={img.url}
+                          showControls={false}
+                          showPlayOverlay
+                          onPlayClick={() => onMediaClick?.(idx, {autoplay: true})}
                         />
                       )}
                     </div>

--- a/app/components/global/ReviewVideoPlayer.tsx
+++ b/app/components/global/ReviewVideoPlayer.tsx
@@ -1,11 +1,21 @@
 import React, {useEffect, useRef, useState} from 'react';
+import {PlayIcon} from 'lucide-react';
 
 interface ReviewVideoPlayerProps {
   src?: string;
   className?: string;
+  showControls?: boolean;
+  showPlayOverlay?: boolean;
+  onPlayClick?: () => void;
 }
 
-const ReviewVideoPlayer = ({src, className}: ReviewVideoPlayerProps) => {
+const ReviewVideoPlayer = ({
+  src,
+  className,
+  showControls = true,
+  showPlayOverlay = false,
+  onPlayClick,
+}: ReviewVideoPlayerProps) => {
   const videoRef = useRef<HTMLVideoElement | null>(null);
   const [poster, setPoster] = useState<string | undefined>();
 
@@ -63,17 +73,29 @@ const ReviewVideoPlayer = ({src, className}: ReviewVideoPlayerProps) => {
   if (!src) return null;
 
   return (
-    <video
-      ref={videoRef}
-      className={className}
-      controls
-      playsInline
-      preload="metadata"
-      crossOrigin="anonymous"
-      // poster='https://fpoxvfuxgtlyphowqdgf.supabase.co/storage/v1/object/public/main-bucket/featured6.png'
-    >
-      <source src={`${src}#t=0.001`} type="video/mp4" />
-    </video>
+    <div className="relative">
+      <video
+        ref={videoRef}
+        className={showControls ? className : `${className ?? ''} pointer-events-none`}
+        controls={showControls}
+        playsInline
+        preload="metadata"
+        crossOrigin="anonymous"
+        poster={poster}
+      >
+        <source src={`${src}#t=0.001`} type="video/mp4" />
+      </video>
+      {showPlayOverlay && (
+        <button
+          type="button"
+          onClick={onPlayClick}
+          className="absolute inset-0 flex items-center justify-center rounded bg-black/20 text-white transition hover:bg-black/40"
+          aria-label="Play video"
+        >
+          <PlayIcon className="h-14 w-14" />
+        </button>
+      )}
+    </div>
   );
 };
 

--- a/components/ui/shadcn-io/carousel-zoom/index.tsx
+++ b/components/ui/shadcn-io/carousel-zoom/index.tsx
@@ -25,12 +25,15 @@ type CarouselZoomItem = {
 
 export type CarouselZoomProps = {
   items: CarouselZoomItem[];
-  children: (openAtIndex: (index: number) => void) => React.ReactNode;
+  children: (
+    openAtIndex: (index: number, options?: {autoplay?: boolean}) => void,
+  ) => React.ReactNode;
 };
 
 export const CarouselZoom = ({items, children}: CarouselZoomProps) => {
   const [isOpen, setIsOpen] = React.useState(false);
   const [zoomIndex, setZoomIndex] = React.useState(0);
+  const [autoPlayIndex, setAutoPlayIndex] = React.useState<number | null>(null);
   const [zoomCarouselApi, setZoomCarouselApi] = React.useState<CarouselApi | null>(
     null,
   );
@@ -84,15 +87,24 @@ export const CarouselZoom = ({items, children}: CarouselZoomProps) => {
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [isOpen, scrollZoomToIndex, zoomCarouselApi, zoomCurrentIndex, zoomTotalItems]);
 
-  const openAtIndex = (index: number) => {
+  const openAtIndex = (index: number, options?: {autoplay?: boolean}) => {
     setZoomIndex(index);
+    setAutoPlayIndex(options?.autoplay ? index : null);
     setIsOpen(true);
   };
 
   return (
     <>
       {children(openAtIndex)}
-      <Dialog open={isOpen} onOpenChange={setIsOpen}>
+      <Dialog
+        open={isOpen}
+        onOpenChange={(open) => {
+          setIsOpen(open);
+          if (!open) {
+            setAutoPlayIndex(null);
+          }
+        }}
+      >
         <DialogPortal>
           <DialogOverlay className="transition-all data-[state=closed]:bg-transparent data-[state=closed]:backdrop-blur-0 data-[state=open]:bg-background/80 data-[state=open]:backdrop-blur-md motion-reduce:transition-none" />
           <DialogPrimitive.Content
@@ -131,6 +143,7 @@ export const CarouselZoom = ({items, children}: CarouselZoomProps) => {
                                 <video
                                   className="max-h-[calc(100vh-12rem)] w-auto max-w-[90vw] rounded-lg"
                                   controls
+                                  autoPlay={isOpen && autoPlayIndex === idx}
                                   playsInline
                                   preload="metadata"
                                   crossOrigin="anonymous"


### PR DESCRIPTION
### Motivation
- Review videos should play inside the existing zoom/dialog UI (the same dialog used for `CarouselZoom`) instead of playing inline in the review card. 
- Single-video reviews need the same dialog behavior as `ReviewMediaCarousel` (open the dialog at the video and autoplay there). 
- The inline review preview should show a single big centered play button with no inline controls while dialog videos should keep normal controls.

### Description
- Added `showControls`, `showPlayOverlay`, and `onPlayClick` props to `ReviewVideoPlayer` and render an overlay play button when requested (`app/components/global/ReviewVideoPlayer.tsx`).
- Updated `ReviewMediaCarousel` to call a generic `onMediaClick` callback and render review thumbnails so video slides show the play overlay and no inline controls (`app/components/global/ReviewMediaCarousel.tsx`).
- Rewired `ProductReviewsDisplay` so single-video reviews reuse `CarouselZoom` and open the dialog when the play overlay is clicked (the dialog receives an autoplay request) (`app/components/global/ProductReviewsDisplay.tsx`).
- Extended `CarouselZoom` to accept an `autoplay` option on `openAtIndex`, track `autoPlayIndex`, and set `autoPlay` on dialog videos when the dialog opens to the requested video while leaving dialog video `controls` intact (`components/ui/shadcn-io/carousel-zoom/index.tsx`).

### Testing
- Attempted to start the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, which errored with an unexpected argument. 
- Attempted `npm run dev -- --port 4173`, which started but reported dependency and MiniOxygen fetch errors and produced network/fetch failures; the UI could not be validated end-to-end in this environment. 
- Code changes were staged and committed successfully (`git commit` completed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978045e27f4832faee5829cceae11de)