### PR TITLE
Adjust bundle carousel controls and hover preview behavior

### DIFF
--- a/app/components/eproducts/EProductBundlePreview.tsx
+++ b/app/components/eproducts/EProductBundlePreview.tsx
@@ -6,6 +6,8 @@ import {
   CarouselApi,
   CarouselContent,
   CarouselItem,
+  CarouselNext,
+  CarouselPrevious,
 } from '../ui/carousel';
 import '../../styles/components/EProductPreview.css';
 
@@ -165,7 +167,19 @@ function EProductBundlePreview({
         ))}
       </CarouselContent>
       {totalItems > 1 && (
-        <div className="carousel-preview-dots absolute bottom-2 left-0 right-0 flex items-end justify-center gap-3 h-24 pt-5">
+        <>
+          <CarouselPrevious
+            inTheBox
+            className="z-10 border-white/60 bg-black/40 text-white hover:bg-black/60"
+          />
+          <CarouselNext
+            inTheBox
+            className="z-10 border-white/60 bg-black/40 text-white hover:bg-black/60"
+          />
+        </>
+      )}
+      {totalItems > 1 && (
+        <div className="carousel-preview-dots absolute bottom-0 left-0 right-0 flex items-end justify-center gap-3 h-24 pt-5">
           {Array.from({length: totalItems}).map((_, idx) => (
             <button
               key={idx}

--- a/app/styles/components/EProductPreview.css
+++ b/app/styles/components/EProductPreview.css
@@ -68,3 +68,10 @@
   /* keep pointer-events none to ensure wrapper handles clicks */
   pointer-events: none;
 }
+.EProductPreviewContainer {
+  position: relative;
+  display: block;
+  width: 100%;
+  overflow: hidden;
+  border-radius: 4px;
+}


### PR DESCRIPTION
### Motivation
- Provide left/right navigation controls on bundle cards so users can move the carousel without interacting with the dots.  
- Ensure hover previews play the specific thumbnail's linked video instead of always playing the first clip.  
- Lower the preview dots slightly for better visual alignment with the card preview area.

### Description
- Imported and rendered `CarouselPrevious` and `CarouselNext` inside `EProductBundlePreview` and passed `inTheBox` to position them at the left and right of the card, adding utility classes for appearance.  
- Adjusted preview-dot row positioning from `bottom-2` to `bottom-0` so the dot row sits lower under the preview.  
- Added `.EProductPreviewContainer { position: relative; }` to `app/styles/components/EProductPreview.css` so the hover video iframe overlays the corresponding thumbnail correctly.  
- Kept existing per-clip hover logic in `BundleClipPreview` so the iframe is only rendered for the hovered clip and toggles visibility via `isVideoReady`.

### Testing
- Ran `npm run dev` to start the Hydrogen dev server, the app reported a running local URL but the server encountered network connection errors and the run did not remain stable. (failed)  
- Attempted an automated browser capture with Playwright (`page.goto('http://localhost:4173')` / `page.screenshot`), which failed with `net::ERR_EMPTY_RESPONSE` because the local server was not reliably reachable. (failed)  
- Verified code changes committed locally with `git` and created the PR; local file diffs show the updated imports, added controls, dot positioning, and CSS container rule. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979ae0c6468832fad051edadf391860)