### PR TITLE
Add tag badges for duration, slow-mo, and 4K

### DIFF
--- a/app/components/eproducts/EProductsContainer.tsx
+++ b/app/components/eproducts/EProductsContainer.tsx
@@ -74,8 +74,11 @@ function EProductsContainer({
   let locationState: string | undefined;
   let locationCountry: string | undefined;
 
-  const durationTag = product.tags.find((t: string) => t?.startsWith?.('duration-'))?.split('-')[1];
-  console.log(durationTag, 'duration')
+  const durationTag = product.tags
+    .find((t: string) => t?.startsWith?.('duration-'))
+    ?.split('-')[1];
+  const isSlowmo = product.tags.includes('slowmo');
+  const hasDurationTag = Boolean(durationTag);
   
 
   const titleCase = (w: string) =>
@@ -191,6 +194,30 @@ function EProductsContainer({
         className={`group relative h-full ${layout === 'list' && 'pb-[12px]'}`}
       >
         <Card className={cardClassName}>
+          <div className="absolute left-2 top-2 z-40 flex flex-col gap-2">
+            {hasDurationTag && (
+              <button
+                disabled
+                className="rounded-md border border-border bg-background p-2 text-white hover:bg-background hover:text-white disabled:cursor-default disabled:opacity-100"
+              >
+                {durationTag}
+              </button>
+            )}
+            {isSlowmo && (
+              <button
+                disabled
+                className="rounded-md border border-border bg-background p-2 text-white hover:bg-background hover:text-white disabled:cursor-default disabled:opacity-100"
+              >
+                Slow-mo
+              </button>
+            )}
+            <button
+              disabled
+              className="rounded-md border border-border bg-background p-2 text-white hover:bg-background hover:text-white disabled:cursor-default disabled:opacity-100"
+            >
+              4K
+            </button>
+          </div>
           {layout === 'list' && windowWidth != undefined && windowWidth <= 600 && (
             <>
             <div
@@ -274,7 +301,6 @@ function EProductsContainer({
           {layout === 'grid' && <div className={cardContentClassName}>
             {layout === 'grid' && (
               <div className="cursor-pointer absolute fav-btn-container-grid z-60 p-1">
-                <div>{durationTag}</div>
                 <TooltipProvider>
                   <Tooltip>
                     <TooltipTrigger asChild>


### PR DESCRIPTION
### Motivation
- Surface product metadata (duration and slow motion) as visual badges on product cards to match existing `durationTag` usage and provide a consistent UI affordance.

### Description
- Add `isSlowmo` detection via `product.tags.includes('slowmo')` and `hasDurationTag` derived from the existing `durationTag` parsing in `EProductsContainer.tsx`.
- Render a stacked set of disabled badge-style buttons in the top-left corner of the card showing the duration (if present), a `Slow-mo` badge when `isSlowmo` is true, and a `4K` badge below both; each badge uses `rounded-md`, `border`, `p-2`, `bg-background`, and white text so they visually match the project background and remain inert on hover/click.
- Keep badges disabled and prevent hover color changes by forcing background/text classes and `disabled` styles; also remove a prior raw `durationTag` `div` that was rendered in the grid favorite button area.
- Change is contained in `app/components/eproducts/EProductsContainer.tsx` (adds ~29 insertions, 3 deletions).

### Testing
- Attempted to start the dev server with `npm run dev -- --host=0.0.0.0 --port=3000`, which failed with `Unexpected argument: 0.0.0.0` so visual verification on a running local server was not completed.
- No automated unit tests were added or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c4ffab648832faebc29a3a7e71c8d)