### PR TITLE
Allow admin checkout without stock form gating

### DIFF
--- a/app/components/CartSummary.tsx
+++ b/app/components/CartSummary.tsx
@@ -2,11 +2,17 @@ import type {CartApiQueryFragment} from 'storefrontapi.generated';
 import type {CartLayout} from '~/components/CartMain';
 import {CartForm, Money, type OptimisticCart} from '@shopify/hydrogen';
 import {useEffect, useRef, useState} from 'react';
-import {FetcherWithComponents, Link, redirect} from '@remix-run/react';
+import {
+  FetcherWithComponents,
+  Link,
+  redirect,
+  useRouteLoaderData,
+} from '@remix-run/react';
 import {Card, CardAction, CardContent, CardHeader} from './ui/card';
 import {Input} from './ui/input';
 import {Button} from './ui/button';
 import StockForm from './form/StockForm';
+import type {RootLoader} from '~/root';
 
 type CartSummaryProps = {
   cart: OptimisticCart<CartApiQueryFragment | null>;
@@ -14,6 +20,8 @@ type CartSummaryProps = {
 };
 
 export function CartSummary({cart, layout}: CartSummaryProps) {
+  const rootData = useRouteLoaderData<RootLoader>('root');
+  const isAdmin = Boolean(rootData?.isAdmin);
   const clipProducts = cart.lines.nodes.filter((item) => {
     //@ts-expect-error not picking up tags somehow
     return item.merchandise.product.tags?.includes('Video');
@@ -22,7 +30,6 @@ export function CartSummary({cart, layout}: CartSummaryProps) {
     (product) => product.merchandise.product.title,
   );
 
-  
   const className =
     layout === 'page' ? 'cart-summary-page' : 'cart-summary-aside';
   // const [isOrderReady, setIsOrderReady] = useState(defaultOrderValue);
@@ -95,7 +102,7 @@ export function CartSummary({cart, layout}: CartSummaryProps) {
         <div className="p-5">
           <CartCheckoutActions
             checkoutUrl={cart.checkoutUrl}
-            disabled={!isOrderReady}
+            disabled={!isAdmin && !isOrderReady}
           />
         </div>
       </div>

--- a/app/components/products/featuredProductReviews.tsx
+++ b/app/components/products/featuredProductReviews.tsx
@@ -5,6 +5,7 @@ import {Separator} from '../ui/separator';
 import type {Review} from '../global/ProductReviewsDisplay';
 import {Rating, RatingButton} from 'components/ui/shadcn-io/rating';
 import {toast} from 'sonner';
+import {ADMIN_CUSTOMER_ID} from '~/lib/admin';
 
 
 interface FeaturedReviewsQuery {
@@ -20,7 +21,6 @@ interface FeaturedReviewsQuery {
 }
 
 type FeaturedReview = Review & {isFeatured?: boolean};
-const ADMIN_CUSTOMER_ID = 'gid://shopify/Customer/7968375079049';
 
 const parseReviewsValue = (value?: string | null) => {
   if (!value) return [] as FeaturedReview[];

--- a/app/lib/admin.ts
+++ b/app/lib/admin.ts
@@ -1,0 +1,1 @@
+export const ADMIN_CUSTOMER_ID = 'gid://shopify/Customer/7968375079049';

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -9,6 +9,7 @@ import {
 import favicon from '~/assets/favicon.svg';
 import {FOOTER_QUERY, HEADER_QUERY} from '~/lib/fragments';
 import {CUSTOMER_WISHLIST} from './lib/customerQueries';
+import {ADMIN_CUSTOMER_ID} from '~/lib/admin';
 
 export type RootLoader = typeof loader;
 
@@ -117,6 +118,8 @@ async function loadCriticalData({context}: LoaderFunctionArgs) {
     console.warn('Not logged in');
     customer = null;
   }
+  const customerId = customer?.data.customer.id ?? null;
+  const isAdmin = customerId === ADMIN_CUSTOMER_ID;
   const wishlistProducts = (() => {
     if (!customer) return [];
 
@@ -135,6 +138,7 @@ async function loadCriticalData({context}: LoaderFunctionArgs) {
   return {
     wishlistProducts,
     header,
+    isAdmin,
   };
 }
 


### PR DESCRIPTION
### Motivation
- Admin users should be able to continue to checkout even when the stock footage licensing form has not been submitted so staff can bypass gating during admin flows.
- Centralize the admin customer identifier so multiple components can consistently detect admin users.
- Expose admin status from root loader so UI components can access it via route loader data.

### Description
- Added `app/lib/admin.ts` exporting `ADMIN_CUSTOMER_ID` for a single source of truth for the admin customer id.
- Updated `app/root.tsx` to import `ADMIN_CUSTOMER_ID`, compute an `isAdmin` flag from the loaded customer, and include `isAdmin` in the root loader return values.
- Updated `app/components/CartSummary.tsx` to read `isAdmin` via `useRouteLoaderData` and keep the Continue to Checkout button enabled when `isAdmin` is true (checkout now disabled only when the user is not admin and the stock form is incomplete).
- Updated `app/components/products/featuredProductReviews.tsx` to import the shared `ADMIN_CUSTOMER_ID` constant instead of defining it inline.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ebb3fcb20832faf1def7489875e5a)