### PR TITLE
Prevent aside dismissal while stock form is open

### DIFF
--- a/app/components/Aside.tsx
+++ b/app/components/Aside.tsx
@@ -48,6 +48,8 @@ export function Aside({
   const imageSource = determineActiveTypeImage();
   const [windowWidth, setWindowWidth] = useState<number | undefined>(undefined);
   const asideRef = useRef<HTMLElement | null>(null);
+  const isStockFormOpen = () =>
+    Boolean(document.querySelector('[data-stockform]'));
 
   useEffect(() => {
     function handleResize() {
@@ -68,6 +70,9 @@ export function Aside({
         (event) => {
           const target = event.target;
           if (!(target instanceof Node)) {
+            return;
+          }
+          if (isStockFormOpen()) {
             return;
           }
           const element =
@@ -101,7 +106,14 @@ export function Aside({
       className={`overlay ${expanded ? 'expanded' : ''}`}
       role="dialog"
     >
-      <button className="close-outside" onClick={close} />
+      <button
+        className="close-outside"
+        onClick={() => {
+          if (!isStockFormOpen()) {
+            close();
+          }
+        }}
+      />
 
       <aside className="border-l" ref={asideRef}>
         {windowWidth != null && windowWidth > 1023 && (


### PR DESCRIPTION
### Motivation
- Prevent the aside from closing when the StockForm modal is open so clicks on the dimmed aside background while the dialog is active do not unintentionally dismiss the aside.

### Description
- Add an `isStockFormOpen()` DOM check in `app/components/Aside.tsx` and use it to short-circuit the document `pointerdown` handler and the overlay `close-outside` button so the aside stays open while the stock form (`[data-stockform]`) exists in the DOM.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697eec5c0e98832f939d98fff67730c2)