### PR TITLE
Add profile contact info and marketing preferences

### DIFF
--- a/app/graphql/customer-account/CustomerDetailsQuery.ts
+++ b/app/graphql/customer-account/CustomerDetailsQuery.ts
@@ -4,6 +4,12 @@ export const CUSTOMER_FRAGMENT = `#graphql
     id
     firstName
     lastName
+    emailAddress {
+      emailAddress
+    }
+    phoneNumber {
+      phoneNumber
+    }
     defaultAddress {
       ...Address
     }
@@ -11,6 +17,15 @@ export const CUSTOMER_FRAGMENT = `#graphql
       nodes {
         ...Address
       }
+    }
+    birthday: metafield(namespace: "custom", key: "birthday") {
+      value
+    }
+    marketingEmail: metafield(namespace: "custom", key: "marketing_email") {
+      value
+    }
+    marketingSms: metafield(namespace: "custom", key: "marketing_sms") {
+      value
     }
     tags
   }

--- a/app/graphql/customer-account/CustomerUpdateMutation.ts
+++ b/app/graphql/customer-account/CustomerUpdateMutation.ts
@@ -5,6 +5,7 @@ export const CUSTOMER_UPDATE_MUTATION = `#graphql
   ){
     customerUpdate(input: $customer) {
       customer {
+        id
         firstName
         lastName
         emailAddress {

--- a/app/routes/account.profile.tsx
+++ b/app/routes/account.profile.tsx
@@ -1,6 +1,9 @@
 import type {CustomerFragment} from 'customer-accountapi.generated';
 import type {CustomerUpdateInput} from '@shopify/hydrogen/customer-account-api-types';
-import {CUSTOMER_UPDATE_MUTATION} from '~/graphql/customer-account/CustomerUpdateMutation';
+import {
+  CUSTOMER_UPDATE_MUTATION,
+  CUSTOMER_UPDATE_WISHLIST,
+} from '~/graphql/customer-account/CustomerUpdateMutation';
 import {
   data,
   type ActionFunctionArgs,
@@ -54,6 +57,10 @@ export async function action({request, context}: ActionFunctionArgs) {
       }
     }
 
+    const birthday = form.get('birthday');
+    const marketingEmail = form.get('marketingEmail') === 'on';
+    const marketingSms = form.get('marketingSms') === 'on';
+
     // update customer and possibly password
     const {data, errors} = await customerAccount.mutate(
       CUSTOMER_UPDATE_MUTATION,
@@ -70,6 +77,52 @@ export async function action({request, context}: ActionFunctionArgs) {
 
     if (!data?.customerUpdate?.customer) {
       throw new Error('Customer profile update failed.');
+    }
+
+    const customerId = data.customerUpdate.customer.id;
+    const metafields = [
+      ...(birthday && typeof birthday === 'string' && birthday.length
+        ? [
+            {
+              key: 'birthday',
+              namespace: 'custom',
+              ownerId: customerId,
+              type: 'date',
+              value: birthday,
+            },
+          ]
+        : []),
+      {
+        key: 'marketing_email',
+        namespace: 'custom',
+        ownerId: customerId,
+        type: 'boolean',
+        value: String(marketingEmail),
+      },
+      {
+        key: 'marketing_sms',
+        namespace: 'custom',
+        ownerId: customerId,
+        type: 'boolean',
+        value: String(marketingSms),
+      },
+    ];
+
+    if (metafields.length) {
+      const metafieldResponse = await customerAccount.mutate(
+        CUSTOMER_UPDATE_WISHLIST,
+        {
+          variables: {
+            metafields,
+          },
+        },
+      );
+
+      const metafieldErrors =
+        metafieldResponse?.data?.metafieldsSet?.userErrors ?? [];
+      if (metafieldErrors.length) {
+        throw new Error(metafieldErrors[0].message);
+      }
     }
 
     return {
@@ -90,78 +143,160 @@ export default function AccountProfile() {
   const account = useOutletContext<{customer: CustomerFragment}>();
   const {state} = useNavigation();
   const action = useActionData<ActionResponse>();
-  const customer = action?.customer ?? account?.customer;
-console.log(customer, 'customer');
+  const customer = action?.customer
+    ? {...account?.customer, ...action?.customer}
+    : account?.customer;
+  const email = customer?.emailAddress?.emailAddress ?? '';
+  const phone = customer?.phoneNumber?.phoneNumber ?? '';
+  const birthday = customer?.birthday?.value ?? '';
+  const marketingEmail = customer?.marketingEmail?.value === 'true';
+  const marketingSms = customer?.marketingSms?.value === 'true';
 
   return (
     <>
-    <Sectiontitle text="My Profile" />
-    <div className="account-profile flex justify-center">
-      <Card className="mx-2 mt-3 w-[95%]">
-        <div className="p-4">
-          <h2>My profile</h2>
-        </div>
-
-        <Form method="PUT">
-          <div className="ps-4">
-            <legend>Account information</legend>
+      <Sectiontitle text="My Profile" />
+      <div className="account-profile flex justify-center">
+        <Card className="mx-2 mt-3 w-[95%]">
+          <div className="p-4">
+            <h2>My profile</h2>
           </div>
-          <CardContent className="ps-4">
-            <fieldset>
-              <label htmlFor="firstName" className="me-2">
-                First name:
-              </label>
-              <div className="py-2">
-                <Input
-                  id="firstName"
-                  name="firstName"
-                  autoComplete="given-name"
-                  placeholder="First name"
-                  aria-label="First name"
-                  defaultValue={customer.firstName ?? ''}
-                  minLength={2}
-                  className="w-[250px]"
-                />
-              </div>
-              <label htmlFor="lastName" className="me-2">
-                Last name:
-              </label>
-              <div className="py-2">
-                <Input
-                  id="lastName"
-                  name="lastName"
-                  autoComplete="family-name"
-                  placeholder="Last name"
-                  aria-label="Last name"
-                  defaultValue={customer.lastName ?? ''}
-                  minLength={2}
-                  className="w-[250px]"
-                />
-              </div>
-            </fieldset>
-            {action?.error ? (
-              <p>
-                <mark>
-                  <small>{action.error}</small>
-                </mark>
-              </p>
-            ) : (
-              <br />
-            )}
-          </CardContent>
-          <CardAction>
-            <Button
-              type="submit"
-              disabled={state !== 'idle'}
-              variant="outline"
-              className="m-5"
-            >
-              {state !== 'idle' ? 'Updating' : 'Update'}
-            </Button>
-          </CardAction>
-        </Form>
-      </Card>
-    </div>
+
+          <Form method="PUT">
+            <div className="ps-4">
+              <legend>Account information</legend>
+            </div>
+            <CardContent className="ps-4">
+              <fieldset>
+                <label htmlFor="firstName" className="me-2">
+                  First name:
+                </label>
+                <div className="py-2">
+                  <Input
+                    id="firstName"
+                    name="firstName"
+                    autoComplete="given-name"
+                    placeholder="First name"
+                    aria-label="First name"
+                    defaultValue={customer.firstName ?? ''}
+                    minLength={2}
+                    className="w-[250px]"
+                  />
+                </div>
+                <label htmlFor="lastName" className="me-2">
+                  Last name:
+                </label>
+                <div className="py-2">
+                  <Input
+                    id="lastName"
+                    name="lastName"
+                    autoComplete="family-name"
+                    placeholder="Last name"
+                    aria-label="Last name"
+                    defaultValue={customer.lastName ?? ''}
+                    minLength={2}
+                    className="w-[250px]"
+                  />
+                </div>
+                <label htmlFor="email" className="me-2">
+                  Email:
+                </label>
+                <div className="py-2">
+                  <Input
+                    id="email"
+                    name="email"
+                    type="email"
+                    autoComplete="email"
+                    placeholder="Email"
+                    aria-label="Email"
+                    defaultValue={email}
+                    readOnly
+                    className="w-[250px]"
+                  />
+                </div>
+                <label htmlFor="phone" className="me-2">
+                  Phone number:
+                </label>
+                <div className="py-2">
+                  <Input
+                    id="phone"
+                    name="phone"
+                    type="tel"
+                    autoComplete="tel"
+                    placeholder="Phone number"
+                    aria-label="Phone number"
+                    defaultValue={phone}
+                    readOnly
+                    className="w-[250px]"
+                  />
+                </div>
+                <label htmlFor="birthday" className="me-2">
+                  Birthday:
+                </label>
+                <div className="py-2">
+                  <Input
+                    id="birthday"
+                    name="birthday"
+                    type="date"
+                    aria-label="Birthday"
+                    defaultValue={birthday}
+                    className="w-[250px]"
+                  />
+                </div>
+                <div className="pt-4">
+                  <h3>Marketing</h3>
+                  <div className="py-2">
+                    <label
+                      htmlFor="marketingEmail"
+                      className="flex items-center gap-2"
+                    >
+                      <input
+                        id="marketingEmail"
+                        name="marketingEmail"
+                        type="checkbox"
+                        defaultChecked={marketingEmail}
+                      />
+                      Subscribed to marketing emails for news and discounts
+                    </label>
+                  </div>
+                  <div className="py-2">
+                    <label
+                      htmlFor="marketingSms"
+                      className="flex items-center gap-2"
+                    >
+                      <input
+                        id="marketingSms"
+                        name="marketingSms"
+                        type="checkbox"
+                        defaultChecked={marketingSms}
+                      />
+                      Subscribed to SMS news and discounts
+                    </label>
+                  </div>
+                </div>
+              </fieldset>
+              {action?.error ? (
+                <p>
+                  <mark>
+                    <small>{action.error}</small>
+                  </mark>
+                </p>
+              ) : (
+                <br />
+              )}
+            </CardContent>
+            <CardAction>
+              <Button
+                type="submit"
+                disabled={state !== 'idle'}
+                variant="outline"
+                className="m-5"
+              >
+                {state !== 'idle' ? 'Updating' : 'Update'}
+              </Button>
+            </CardAction>
+          </Form>
+        </Card>
+      </div>
     </>
   );
 }

--- a/customer-accountapi.generated.d.ts
+++ b/customer-accountapi.generated.d.ts
@@ -68,8 +68,14 @@ export type CustomerAddressCreateMutation = {
 
 export type CustomerFragment = Pick<
   CustomerAccountAPI.Customer,
-  'id' | 'firstName' | 'lastName'
+  'id' | 'firstName' | 'lastName' | 'tags'
 > & {
+  emailAddress?: CustomerAccountAPI.Maybe<
+    Pick<CustomerAccountAPI.CustomerEmailAddress, 'emailAddress'>
+  >;
+  phoneNumber?: CustomerAccountAPI.Maybe<
+    Pick<CustomerAccountAPI.CustomerPhoneNumber, 'phoneNumber'>
+  >;
   defaultAddress?: CustomerAccountAPI.Maybe<
     Pick<
       CustomerAccountAPI.CustomerAddress,
@@ -106,6 +112,15 @@ export type CustomerFragment = Pick<
       >
     >;
   };
+  birthday?: CustomerAccountAPI.Maybe<
+    Pick<CustomerAccountAPI.Metafield, 'value'>
+  >;
+  marketingEmail?: CustomerAccountAPI.Maybe<
+    Pick<CustomerAccountAPI.Metafield, 'value'>
+  >;
+  marketingSms?: CustomerAccountAPI.Maybe<
+    Pick<CustomerAccountAPI.Metafield, 'value'>
+  >;
 };
 
 export type AddressFragment = Pick<
@@ -131,8 +146,14 @@ export type CustomerDetailsQueryVariables = CustomerAccountAPI.Exact<{
 export type CustomerDetailsQuery = {
   customer: Pick<
     CustomerAccountAPI.Customer,
-    'id' | 'firstName' | 'lastName'
+    'id' | 'firstName' | 'lastName' | 'tags'
   > & {
+    emailAddress?: CustomerAccountAPI.Maybe<
+      Pick<CustomerAccountAPI.CustomerEmailAddress, 'emailAddress'>
+    >;
+    phoneNumber?: CustomerAccountAPI.Maybe<
+      Pick<CustomerAccountAPI.CustomerPhoneNumber, 'phoneNumber'>
+    >;
     defaultAddress?: CustomerAccountAPI.Maybe<
       Pick<
         CustomerAccountAPI.CustomerAddress,
@@ -169,6 +190,15 @@ export type CustomerDetailsQuery = {
         >
       >;
     };
+    birthday?: CustomerAccountAPI.Maybe<
+      Pick<CustomerAccountAPI.Metafield, 'value'>
+    >;
+    marketingEmail?: CustomerAccountAPI.Maybe<
+      Pick<CustomerAccountAPI.Metafield, 'value'>
+    >;
+    marketingSms?: CustomerAccountAPI.Maybe<
+      Pick<CustomerAccountAPI.Metafield, 'value'>
+    >;
   };
 };
 
@@ -451,7 +481,7 @@ export type CustomerUpdateMutationVariables = CustomerAccountAPI.Exact<{
 export type CustomerUpdateMutation = {
   customerUpdate?: CustomerAccountAPI.Maybe<{
     customer?: CustomerAccountAPI.Maybe<
-      Pick<CustomerAccountAPI.Customer, 'firstName' | 'lastName'> & {
+      Pick<CustomerAccountAPI.Customer, 'id' | 'firstName' | 'lastName'> & {
         emailAddress?: CustomerAccountAPI.Maybe<
           Pick<CustomerAccountAPI.CustomerEmailAddress, 'emailAddress'>
         >;
@@ -470,7 +500,7 @@ export type CustomerUpdateMutation = {
 };
 
 interface GeneratedQueryTypes {
-  '#graphql\n  query CustomerDetails {\n    customer {\n      ...Customer\n    }\n  }\n  #graphql\n  fragment Customer on Customer {\n    id\n    firstName\n    lastName\n    defaultAddress {\n      ...Address\n    }\n    addresses(first: 6) {\n      nodes {\n        ...Address\n      }\n    }\n  }\n  fragment Address on CustomerAddress {\n    id\n    formatted\n    firstName\n    lastName\n    company\n    address1\n    address2\n    territoryCode\n    zoneCode\n    city\n    zip\n    phoneNumber\n  }\n\n': {
+  '#graphql\n  query CustomerDetails {\n    customer {\n      ...Customer\n    }\n  }\n  #graphql\n  fragment Customer on Customer {\n    id\n    firstName\n    lastName\n    emailAddress {\n      emailAddress\n    }\n    phoneNumber {\n      phoneNumber\n    }\n    defaultAddress {\n      ...Address\n    }\n    addresses(first: 6) {\n      nodes {\n        ...Address\n      }\n    }\n    birthday: metafield(namespace: \"custom\", key: \"birthday\") {\n      value\n    }\n    marketingEmail: metafield(namespace: \"custom\", key: \"marketing_email\") {\n      value\n    }\n    marketingSms: metafield(namespace: \"custom\", key: \"marketing_sms\") {\n      value\n    }\n    tags\n  }\n  fragment Address on CustomerAddress {\n    id\n    formatted\n    firstName\n    lastName\n    company\n    address1\n    address2\n    territoryCode\n    zoneCode\n    city\n    zip\n    phoneNumber\n  }\n\n': {
     return: CustomerDetailsQuery;
     variables: CustomerDetailsQueryVariables;
   };
@@ -497,7 +527,7 @@ interface GeneratedMutationTypes {
     return: CustomerAddressCreateMutation;
     variables: CustomerAddressCreateMutationVariables;
   };
-  '#graphql\n  # https://shopify.dev/docs/api/customer/latest/mutations/customerUpdate\n  mutation customerUpdate(\n    $customer: CustomerUpdateInput!\n  ){\n    customerUpdate(input: $customer) {\n      customer {\n        firstName\n        lastName\n        emailAddress {\n          emailAddress\n        }\n        phoneNumber {\n          phoneNumber\n        }\n      }\n      userErrors {\n        code\n        field\n        message\n      }\n    }\n  }\n': {
+  '#graphql\n  # https://shopify.dev/docs/api/customer/latest/mutations/customerUpdate\n  mutation customerUpdate(\n    $customer: CustomerUpdateInput!\n  ){\n    customerUpdate(input: $customer) {\n      customer {\n        id\n        firstName\n        lastName\n        emailAddress {\n          emailAddress\n        }\n        phoneNumber {\n          phoneNumber\n        }\n      }\n      userErrors {\n        code\n        field\n        message\n      }\n    }\n  }\n': {
     return: CustomerUpdateMutation;
     variables: CustomerUpdateMutationVariables;
   };


### PR DESCRIPTION
### Motivation
- Surface additional customer contact data and profile preferences (email, phone, birthday, marketing opt-ins) on the profile page so customers can view and update them. 
- Persist birthday and marketing opt-ins as Shopify customer metafields when the user updates their profile so values remain across visits.

### Description
- Expanded `CUSTOMER_FRAGMENT` in `app/graphql/customer-account/CustomerDetailsQuery.ts` to fetch `emailAddress`, `phoneNumber`, and customer metafields for `birthday`, `marketing_email`, and `marketing_sms`.
- Added `id` to the `CUSTOMER_UPDATE_MUTATION` response and updated generated types in `customer-accountapi.generated.d.ts` to reflect the new fields and query shape.
- Updated `app/routes/account.profile.tsx` to add read-only contact inputs for email and phone, a `date` input for birthday, and two marketing preference checkboxes, and to merge updated customer data into the outlet context for UI refresh.
- Implemented save logic in the profile action to call `CUSTOMER_UPDATE_MUTATION` for name changes and then persist `birthday`, `marketing_email`, and `marketing_sms` metafields via the existing `metafieldsSet` mutation (`CUSTOMER_UPDATE_WISHLIST`).

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69802a8d90b8832f8158747264a382c0)