### PR TITLE
Use marketing subscribe/unsubscribe mutations and fix birthday metafield update in profile

### DIFF
--- a/app/graphql/customer-account/CustomerDetailsQuery.ts
+++ b/app/graphql/customer-account/CustomerDetailsQuery.ts
@@ -6,9 +6,11 @@ export const CUSTOMER_FRAGMENT = `#graphql
     lastName
     emailAddress {
       emailAddress
+      marketingState
     }
     phoneNumber {
       phoneNumber
+      marketingState
     }
     defaultAddress {
       ...Address
@@ -19,12 +21,6 @@ export const CUSTOMER_FRAGMENT = `#graphql
       }
     }
     birthday: metafield(namespace: "custom", key: "birthday") {
-      value
-    }
-    marketingEmail: metafield(namespace: "custom", key: "marketing_email") {
-      value
-    }
-    marketingSms: metafield(namespace: "custom", key: "marketing_sms") {
       value
     }
     tags

--- a/app/graphql/customer-account/CustomerUpdateMutation.ts
+++ b/app/graphql/customer-account/CustomerUpdateMutation.ts
@@ -42,3 +42,35 @@ export const CUSTOMER_UPDATE_WISHLIST =
   }
 }
 ` as const;
+
+export const CUSTOMER_EMAIL_MARKETING_SUBSCRIBE = `#graphql
+  mutation CustomerEmailMarketingSubscribe {
+    customerEmailMarketingSubscribe {
+      emailAddress {
+        emailAddress
+        marketingState
+      }
+      userErrors {
+        field
+        message
+        code
+      }
+    }
+  }
+` as const;
+
+export const CUSTOMER_EMAIL_MARKETING_UNSUBSCRIBE = `#graphql
+  mutation CustomerEmailMarketingUnsubscribe {
+    customerEmailMarketingUnsubscribe {
+      emailAddress {
+        emailAddress
+        marketingState
+      }
+      userErrors {
+        field
+        message
+        code
+      }
+    }
+  }
+` as const;

--- a/customer-accountapi.generated.d.ts
+++ b/customer-accountapi.generated.d.ts
@@ -71,10 +71,10 @@ export type CustomerFragment = Pick<
   'id' | 'firstName' | 'lastName' | 'tags'
 > & {
   emailAddress?: CustomerAccountAPI.Maybe<
-    Pick<CustomerAccountAPI.CustomerEmailAddress, 'emailAddress'>
+    Pick<CustomerAccountAPI.CustomerEmailAddress, 'emailAddress' | 'marketingState'>
   >;
   phoneNumber?: CustomerAccountAPI.Maybe<
-    Pick<CustomerAccountAPI.CustomerPhoneNumber, 'phoneNumber'>
+    Pick<CustomerAccountAPI.CustomerPhoneNumber, 'phoneNumber' | 'marketingState'>
   >;
   defaultAddress?: CustomerAccountAPI.Maybe<
     Pick<
@@ -115,12 +115,6 @@ export type CustomerFragment = Pick<
   birthday?: CustomerAccountAPI.Maybe<
     Pick<CustomerAccountAPI.Metafield, 'value'>
   >;
-  marketingEmail?: CustomerAccountAPI.Maybe<
-    Pick<CustomerAccountAPI.Metafield, 'value'>
-  >;
-  marketingSms?: CustomerAccountAPI.Maybe<
-    Pick<CustomerAccountAPI.Metafield, 'value'>
-  >;
 };
 
 export type AddressFragment = Pick<
@@ -149,10 +143,10 @@ export type CustomerDetailsQuery = {
     'id' | 'firstName' | 'lastName' | 'tags'
   > & {
     emailAddress?: CustomerAccountAPI.Maybe<
-      Pick<CustomerAccountAPI.CustomerEmailAddress, 'emailAddress'>
+      Pick<CustomerAccountAPI.CustomerEmailAddress, 'emailAddress' | 'marketingState'>
     >;
     phoneNumber?: CustomerAccountAPI.Maybe<
-      Pick<CustomerAccountAPI.CustomerPhoneNumber, 'phoneNumber'>
+      Pick<CustomerAccountAPI.CustomerPhoneNumber, 'phoneNumber' | 'marketingState'>
     >;
     defaultAddress?: CustomerAccountAPI.Maybe<
       Pick<
@@ -191,12 +185,6 @@ export type CustomerDetailsQuery = {
       >;
     };
     birthday?: CustomerAccountAPI.Maybe<
-      Pick<CustomerAccountAPI.Metafield, 'value'>
-    >;
-    marketingEmail?: CustomerAccountAPI.Maybe<
-      Pick<CustomerAccountAPI.Metafield, 'value'>
-    >;
-    marketingSms?: CustomerAccountAPI.Maybe<
       Pick<CustomerAccountAPI.Metafield, 'value'>
     >;
   };
@@ -500,7 +488,7 @@ export type CustomerUpdateMutation = {
 };
 
 interface GeneratedQueryTypes {
-  '#graphql\n  query CustomerDetails {\n    customer {\n      ...Customer\n    }\n  }\n  #graphql\n  fragment Customer on Customer {\n    id\n    firstName\n    lastName\n    emailAddress {\n      emailAddress\n    }\n    phoneNumber {\n      phoneNumber\n    }\n    defaultAddress {\n      ...Address\n    }\n    addresses(first: 6) {\n      nodes {\n        ...Address\n      }\n    }\n    birthday: metafield(namespace: \"custom\", key: \"birthday\") {\n      value\n    }\n    marketingEmail: metafield(namespace: \"custom\", key: \"marketing_email\") {\n      value\n    }\n    marketingSms: metafield(namespace: \"custom\", key: \"marketing_sms\") {\n      value\n    }\n    tags\n  }\n  fragment Address on CustomerAddress {\n    id\n    formatted\n    firstName\n    lastName\n    company\n    address1\n    address2\n    territoryCode\n    zoneCode\n    city\n    zip\n    phoneNumber\n  }\n\n': {
+  '#graphql\n  query CustomerDetails {\n    customer {\n      ...Customer\n    }\n  }\n  #graphql\n  fragment Customer on Customer {\n    id\n    firstName\n    lastName\n    emailAddress {\n      emailAddress\n      marketingState\n    }\n    phoneNumber {\n      phoneNumber\n      marketingState\n    }\n    defaultAddress {\n      ...Address\n    }\n    addresses(first: 6) {\n      nodes {\n        ...Address\n      }\n    }\n    birthday: metafield(namespace: \"custom\", key: \"birthday\") {\n      value\n    }\n    tags\n  }\n  fragment Address on CustomerAddress {\n    id\n    formatted\n    firstName\n    lastName\n    company\n    address1\n    address2\n    territoryCode\n    zoneCode\n    city\n    zip\n    phoneNumber\n  }\n\n': {
     return: CustomerDetailsQuery;
     variables: CustomerDetailsQueryVariables;
   };


### PR DESCRIPTION
### Motivation
- Prevent forbidden metafield writes that caused "Access to this namespace and key on Metafields for this resource type is not allowed" by switching to the platform-provided email marketing mutations. 
- Ensure the birthday chosen in the profile saves and that the UI reflects updated values after an update.

### Description
- Added `CUSTOMER_EMAIL_MARKETING_SUBSCRIBE` and `CUSTOMER_EMAIL_MARKETING_UNSUBSCRIBE` mutations and switched profile marketing updates to call these instead of writing marketing metafields. 
- Limited metafield writes to only the `birthday` metafield via `metafieldsSet` and return the updated `birthday` and `marketingEmail` in the action response for UI refresh. 
- Updated `CUSTOMER_FRAGMENT`/`CUSTOMER_DETAILS_QUERY` to fetch `marketingState` on `emailAddress` and `phoneNumber` and removed marketing metafields from the fragment. 
- Adjusted generated types in `customer-accountapi.generated.d.ts` and updated `app/routes/account.profile.tsx` to use the new fields and to treat `PENDING` as checked so the checkbox reflects recent opt-in state.

### Testing
- No automated tests were executed for this change (no test run was requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69802f1c1c6c832f9d22e55262313084)