### PR TITLE
Fix account profile action response format

### DIFF
--- a/app/routes/account.profile.tsx
+++ b/app/routes/account.profile.tsx
@@ -121,12 +121,12 @@ export async function action({request, context}: ActionFunctionArgs) {
       throw new Error(marketingErrors[0].message);
     }
 
-    return {
+    return data({
       error: null,
-      customer: data?.customerUpdate?.customer,
+      customer: data?.customerUpdate?.customer ?? null,
       birthday: typeof birthday === 'string' ? birthday : undefined,
       marketingEmail,
-    };
+    });
   } catch (error: any) {
     return data(
       {error: error.message, customer: null},


### PR DESCRIPTION
### Motivation
- Ensure the profile action returns a proper serialized Remix response and a stable `customer` shape so the client can decode the update payload and avoid turbo-stream / hydration errors.

### Description
- Replace the plain object return with `data({...})` and make `customer` `data?.customerUpdate?.customer ?? null`, while preserving `birthday` and `marketingEmail` in the action response.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698031d58008832faa7dd35e69889bda)