### PR TITLE
Require explicit Admin domain for SMS consent updates and bump Admin API version

### DIFF
--- a/app/routes/account.profile.tsx
+++ b/app/routes/account.profile.tsx
@@ -129,14 +129,25 @@ export async function action({request, context}: ActionFunctionArgs) {
     if (marketingSms !== currentMarketingSms) {
       const adminToken = context.env.SHOPIFY_ADMIN_TOKEN;
       const storeDomain = context.env.PUBLIC_STORE_DOMAIN;
+      const adminDomainEnv = context.env.SHOPIFY_ADMIN_DOMAIN;
 
       if (!adminToken || !storeDomain) {
         throw new Error('Missing admin credentials to update SMS consent.');
       }
 
-      const adminDomain = storeDomain.replace(/^https?:\/\//, '');
+      const sanitizedStoreDomain = storeDomain.replace(/^https?:\/\//, '');
+      const adminDomain =
+        adminDomainEnv?.replace(/^https?:\/\//, '') ??
+        (sanitizedStoreDomain.includes('myshopify.com')
+          ? sanitizedStoreDomain
+          : null);
+      if (!adminDomain) {
+        throw new Error(
+          'Missing SHOPIFY_ADMIN_DOMAIN for Admin API requests.',
+        );
+      }
       const smsResponse = await fetch(
-        `https://${adminDomain}/admin/api/2024-10/graphql.json`,
+        `https://${adminDomain}/admin/api/2025-01/graphql.json`,
         {
           method: 'POST',
           headers: {

--- a/env.d.ts
+++ b/env.d.ts
@@ -21,6 +21,7 @@ declare global {
   interface Env extends HydrogenEnv {
     // declare additional Env parameter use in the fetch handler and Remix loader context here
     SHOPIFY_ADMIN_TOKEN: string;
+    SHOPIFY_ADMIN_DOMAIN: string;
     SUPABASE_KEY: string;
     SUPABASE_URL: string;
   }


### PR DESCRIPTION
### Motivation

- Remove a hardcoded myshopify fallback and require an explicit Admin domain to avoid embedding or assuming a shop myshopify host in code.
- Ensure Admin API requests for updating SMS marketing consent are performed server-side using a configurable domain rather than producing any client-side redirects.
- Use a newer Admin API version (`2025-01`) so the `SmsMarketingConsent` input types required by the mutation are available.

### Description

- Read `SHOPIFY_ADMIN_DOMAIN` from the server environment in `app/routes/account.profile.tsx` and sanitize it by stripping any `http(s)://` prefix before use.
- Remove the hardcoded fallback (`fuyqg4-fh.myshopify.com`) and throw a clear error when no admin domain can be derived from `PUBLIC_STORE_DOMAIN` and `SHOPIFY_ADMIN_DOMAIN` is not provided.
- Update the Admin GraphQL endpoint from `2024-10` to `2025-01` for the customer SMS marketing consent mutation.
- Add `SHOPIFY_ADMIN_DOMAIN` to the environment typings in `env.d.ts` so the new configuration is explicit and type-checked.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69803a0fdda8832f9a3c255938c43bf1)