### PR TITLE
Avoid shadowing Remix `data` helper in account.profile action

### DIFF
--- a/app/routes/account.profile.tsx
+++ b/app/routes/account.profile.tsx
@@ -91,7 +91,7 @@ export async function action({request, context}: ActionFunctionArgs) {
     const currentMarketingSms = form.get('currentMarketingSms') === 'true';
 
     // update customer and possibly password
-    const {data, errors} = await customerAccount.mutate(
+    const {data: mutationData, errors} = await customerAccount.mutate(
       CUSTOMER_UPDATE_MUTATION,
       {
         variables: {
@@ -104,11 +104,11 @@ export async function action({request, context}: ActionFunctionArgs) {
       throw new Error(errors[0].message);
     }
 
-    if (!data?.customerUpdate?.customer) {
+    if (!mutationData?.customerUpdate?.customer) {
       throw new Error('Customer profile update failed.');
     }
 
-    const customerId = data.customerUpdate.customer.id;
+    const customerId = mutationData.customerUpdate.customer.id;
 
     if (marketingEmail !== currentMarketingEmail) {
       const marketingMutation = marketingEmail
@@ -192,7 +192,7 @@ export async function action({request, context}: ActionFunctionArgs) {
 
     return data({
       error: null,
-      customer: data?.customerUpdate?.customer ?? null,
+      customer: mutationData?.customerUpdate?.customer ?? null,
       marketingEmail,
       marketingSms,
     });


### PR DESCRIPTION
### Motivation
- Fix a runtime error where the `data` binding from a GraphQL mutation shadowed the imported Remix `data` helper, causing the profile update (marketing checkbox) action to return a malformed response (e.g. `data2 is not a function`).

### Description
- Rename the mutation result `data` to `mutationData` and update all references (`const {data: mutationData, errors}` and uses) in `app/routes/account.profile.tsx` so the Remix `data` helper is not shadowed and the action response uses the correct mutation payload.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69803dbe0aec832fa15b92ee4de0f67d)