### PR TITLE
Update branding to "Adam Underwater" and round header/logo icons

### DIFF
--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -18,7 +18,7 @@ import {CUSTOMER_WISHLIST} from '~/lib/customerQueries';
 import FeaturedProductReviews from '~/components/products/featuredProductReviews';
 
 export const meta: MetaFunction = () => {
-  return [{title: 'Hydrogen | Home'}];
+  return [{title: 'Adam Underwater | Home'}];
 };
 
 export async function loader(args: LoaderFunctionArgs) {

--- a/app/routes/blogs.$blogHandle.$articleHandle.tsx
+++ b/app/routes/blogs.$blogHandle.$articleHandle.tsx
@@ -3,7 +3,7 @@ import {useLoaderData, type MetaFunction} from '@remix-run/react';
 import {Image} from '@shopify/hydrogen';
 
 export const meta: MetaFunction<typeof loader> = ({data}) => {
-  return [{title: `Hydrogen | ${data?.article.title ?? ''} article`}];
+  return [{title: `Adam Underwater | ${data?.article.title ?? ''} article`}];
 };
 
 export async function loader(args: LoaderFunctionArgs) {

--- a/app/routes/blogs.$blogHandle._index.tsx
+++ b/app/routes/blogs.$blogHandle._index.tsx
@@ -5,7 +5,7 @@ import type {ArticleItemFragment} from 'storefrontapi.generated';
 import {PaginatedResourceSection} from '~/components/PaginatedResourceSection';
 
 export const meta: MetaFunction<typeof loader> = ({data}) => {
-  return [{title: `Hydrogen | ${data?.blog.title ?? ''} blog`}];
+  return [{title: `Adam Underwater | ${data?.blog.title ?? ''} blog`}];
 };
 
 export async function loader(args: LoaderFunctionArgs) {

--- a/app/routes/blogs._index.tsx
+++ b/app/routes/blogs._index.tsx
@@ -4,7 +4,7 @@ import {getPaginationVariables} from '@shopify/hydrogen';
 import {PaginatedResourceSection} from '~/components/PaginatedResourceSection';
 
 export const meta: MetaFunction = () => {
-  return [{title: `Hydrogen | Blogs`}];
+  return [{title: `Adam Underwater | Blogs`}];
 };
 
 export async function loader(args: LoaderFunctionArgs) {

--- a/app/routes/cart.tsx
+++ b/app/routes/cart.tsx
@@ -10,7 +10,7 @@ import {
 import {CartMain} from '~/components/CartMain';
 
 export const meta: MetaFunction = () => {
-  return [{title: `Hydrogen | Cart`}];
+  return [{title: `Adam Underwater | Cart`}];
 };
 
 export const headers: HeadersFunction = ({actionHeaders}) => actionHeaders;

--- a/app/routes/collections.$handle.tsx
+++ b/app/routes/collections.$handle.tsx
@@ -48,7 +48,7 @@ import {CUSTOMER_WISHLIST} from '~/lib/customerQueries';
 import RecommendedProducts from '~/components/products/recommendedProducts';
 
 export const meta: MetaFunction<typeof loader> = ({data}) => {
-  return [{title: `Hydrogen | ${data?.collection?.title ?? ''} Collection`}];
+  return [{title: `Adam Underwater | ${data?.collection?.title ?? ''} Collection`}];
 };
 
 export async function loader(args: LoaderFunctionArgs) {

--- a/app/routes/collections.all.tsx
+++ b/app/routes/collections.all.tsx
@@ -19,7 +19,7 @@ import {useEffect, useState} from 'react';
 import {shopifyImage} from '~/lib/types';
 
 export const meta: MetaFunction<typeof loader> = () => {
-  return [{title: `Hydrogen | Products`}];
+  return [{title: `Adam Underwater | Products`}];
 };
 
 export async function loader(args: LoaderFunctionArgs) {

--- a/app/routes/pages.$handle.tsx
+++ b/app/routes/pages.$handle.tsx
@@ -2,7 +2,7 @@ import {type LoaderFunctionArgs} from '@shopify/remix-oxygen';
 import {useLoaderData, type MetaFunction} from '@remix-run/react';
 
 export const meta: MetaFunction<typeof loader> = ({data}) => {
-  return [{title: `Hydrogen | ${data?.page.title ?? ''}`}];
+  return [{title: `Adam Underwater | ${data?.page.title ?? ''}`}];
 };
 
 export async function loader(args: LoaderFunctionArgs) {

--- a/app/routes/policies.$handle.tsx
+++ b/app/routes/policies.$handle.tsx
@@ -10,7 +10,7 @@ type SelectedPolicies = keyof Pick<
 >;
 
 export const meta: MetaFunction<typeof loader> = ({data}) => {
-  return [{title: `Hydrogen | ${data?.policy.title ?? ''}`}];
+  return [{title: `Adam Underwater | ${data?.policy.title ?? ''}`}];
 };
 
 export async function loader({params, context}: LoaderFunctionArgs) {

--- a/app/routes/products.$handle.tsx
+++ b/app/routes/products.$handle.tsx
@@ -70,7 +70,7 @@ import {CUSTOMER_WISHLIST} from '~/lib/customerQueries';
 
 export const meta: MetaFunction<typeof loader> = ({data}) => {
   return [
-    {title: `Hydrogen | ${data?.product.title ?? ''}`},
+    {title: `Adam Underwater | ${data?.product.title ?? ''}`},
     {
       rel: 'canonical',
       href: `/products/${data?.product.handle}`,

--- a/app/routes/search.tsx
+++ b/app/routes/search.tsx
@@ -17,7 +17,7 @@ import {useEffect, useState} from 'react';
 import {CUSTOMER_WISHLIST} from '~/lib/customerQueries';
 
 export const meta: MetaFunction = () => {
-  return [{title: `Hydrogen | Search`}];
+  return [{title: `Adam Underwater | Search`}];
 };
 
 export async function loader({request, context}: LoaderFunctionArgs) {

--- a/app/styles/app.css
+++ b/app/styles/app.css
@@ -616,6 +616,7 @@ button.reset:hover:not(:has(> *)) {
 
 .logo {
   height: 2.5rem;
+  border-radius: 0.375rem;
 }
 @media (min-width: 601px) {
   .cart-header {
@@ -1559,6 +1560,7 @@ span {
   }
   .icon-header {
     height: 52px;
+    border-radius: 0.375rem;
   }
   .work-header {
     height: 40px;


### PR DESCRIPTION
### Motivation
- Replace all user-facing page titles that read "Hydrogen" so the site brand reads "Adam Underwater" instead. 
- Soften the visuals by adding a small corner radius to the logo and header icons (equivalent to Tailwind's `rounded-md`).

### Description
- Update meta titles in route files under `app/routes/*` to use `Adam Underwater` instead of `Hydrogen` for page tabs and titles. 
- Add `border-radius: 0.375rem;` to `.logo` and `.icon-header` in `app/styles/app.css` to achieve a `rounded-md` look for the logo and header icons. 
- Performed an automated replacement via a small Python script and verified changes by searching the routes.

### Testing
- Ran the automated Python replacement script to update titles across `app/routes`, which completed successfully. 
- Verified replacements with search (`rg`) to confirm `Adam Underwater` appears in the updated route files. 
- Attempted to start the dev server with `npm run dev` to validate the site, but the dev server failed to start due to dependency resolution / network errors (so runtime validation was not completed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69804b3f42f4832fb5e227db33635be1)